### PR TITLE
Implement cons pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ Given a lisp-program output the assembly version of that program, which may be c
       (print (fact 9))
       (print (fact 10))
 
-      ;; exit code
+      ;; exit code - use "(exit 3)" if you prefer
       0)
 ```
 
-See [example.lisp](example.lisp) for a genuine/bigger example.
+See [example.lisp](example.lisp) for a genuine/bigger example, including a more complex `print` definition that understands `nil` and cons pairs.
 
 
 
 ## Features
 
-* Support for functions, bindings, and most mathematical operations.
-* Support for integers and strings.
-  * We have `(int? x)` and `(str? y)` to let you do run-time type-detection.
+* Support for functions, bindings, and basic mathematical operations.
+* Support for integers, nil, strings and cons pairs.
+  * We have some run-time type detection via functions
+    * `(cons? x)` - True if the item is a cons pair.
+    * `(int? x)` - True if the item is an int.
+    * `(nil? x)` - True if the item is nil.
+    * `(str? y)` - True if the item is a string.
 * Primitives
   * `(printint 3)` - prints the given number to STDOUT.
   * `(printstr "Steve")` - prints the given string to STDOUT.
@@ -57,7 +61,10 @@ See [example.lisp](example.lisp) for a genuine/bigger example.
 
 Anti-features:
 
-* No lists, no lambdas, no closures, and no cons-cells.
+* No true lists, just cons pairs
+* No lambdas
+* No closures.
+* No "setq" or "set!" for global variables.
 
 
 

--- a/example.lisp
+++ b/example.lisp
@@ -112,6 +112,7 @@
       ; create a cons cell, and print it :)
       (println (cons (cons (cons 12 31) 392) nil))
 
+      (println (cons 1 (cons 2 (cons 3 nil))))
       ;; return value is the last thing compiled.
       0
       ;; You can be more explicit with (exit 0)

--- a/example.lisp
+++ b/example.lisp
@@ -1,17 +1,22 @@
-;; if the value is a number?  print it as an integer.
-;; otherwise print it as a string
+;; Print the given item intelligently.
+;; We handle integers, strings, nil and cons pairs.
 (defun print (x)
   (if (int? x)
       (printint x))
+  (if (nil? x)
+      (printstr "<nil>"))
   (if (str? x)
       (printstr x))
   (if (cons? x)
       (do
+       (putc 40)       ; (
+       (print (car x))
+       (putc 32)       ; space
+       (putc 46)       ; .
+       (putc 32)       ; space
        (print (cdr x))
-       (putc 32)  ; space
-       (putc 46)  ; .
-       (putc 32)  ; space
-       (print (cdr x)))))
+       (putc 41)       ; )
+       )))
 
 (defun println (x)
   (print x)
@@ -102,8 +107,10 @@
       ;(putc 42)
       ;(putc 10)
 
+      (println nil)
+
       ; create a cons cell, and print it :)
-      (println (cons 2 3 ))
+      (println (cons (cons (cons 12 31) 392) nil))
 
       ;; return value is the last thing compiled.
       0

--- a/example.lisp
+++ b/example.lisp
@@ -2,8 +2,19 @@
 ;; otherwise print it as a string
 (defun print (x)
   (if (int? x)
-      (printint x)
+      (printint x))
+  (if (str? x)
       (printstr x))
+  (if (cons? x)
+      (do
+       (print (cdr x))
+       (putc 32)  ; space
+       (putc 46)  ; .
+       (putc 32)  ; space
+       (print (cdr x)))))
+
+(defun println (x)
+  (print x)
   (newline))
 
 ;; Add one to the argument
@@ -29,67 +40,70 @@
   (let ((x (double 13)) (y 12))
     (do
      (if 1
-         (print "Hello, I am if!"))
+         (println "Hello, I am if!"))
 
-      (print "Hello World!")
-      (print "I am compiled lisp.  kinda.")
-      (print "Some random maths")
+      (println "Hello World!")
+      (println "I am compiled lisp.  kinda.")
+      (println "Some random maths")
        ;; print 12 * 12 -> 144
-      (print (square y))
+      (println (square y))
 
       ;; print 13 * 2 * 2 -> 52.
-      (print (double x))
+      (println (double x))
 
       ;; little countdown to test maths
-      (print "Counting down from 10-0")
-      (print (+ (* 4 2) 2))
+      (println "Counting down from 10-0")
+      (println (+ (* 4 2) 2))
       ;; 9
-      (print (- 10 1))
+      (println (- 10 1))
       ;; 8
-      (print (+ 6 2))
+      (println (+ 6 2))
       ;; 7
-      (print (/ 14 2))
+      (println (/ 14 2))
       ;; 6
-      (print (* 3 2))
+      (println (* 3 2))
       ;; 5
-      (print (- 30 (* 5 5)))
+      (println (- 30 (* 5 5)))
       ;; 4
-      (print (/ 8 2))
+      (println (/ 8 2))
       ;; 3
-      (print (+ (* 2 1) 1))
+      (println (+ (* 2 1) 1))
       ;; 2
-      (print (- (* 10 10) 98))
+      (println (- (* 10 10) 98))
       ;; 1
-      (print (- 3 2))
+      (println (- 3 2))
       ;; 0
-      (print (- 98 98))
+      (println (- 98 98))
 
       ;; now some factorials.
-      (print "Showing results of factorial - 1-20")
-      (print (fact 1))
-      (print (fact 2))
-      (print (fact 3))
-      (print (fact 4))
-      (print (fact 5))
-      (print (fact 6))
-      (print (fact 7))
-      (print (fact 8))
-      (print (fact 9))
-      (print (fact 10))
-      (print (fact 11))
-      (print (fact 12))
-      (print (fact 13))
-      (print (fact 14))
-      (print (fact 15))
-      (print (fact 16))
-      (print (fact 17))
-      (print (fact 18))
-      (print (fact 19))
-      (print (fact 20))
+      (println "Showing results of factorial - 1-20")
+      (println (fact 1))
+      (println (fact 2))
+      (println (fact 3))
+      (println (fact 4))
+      (println (fact 5))
+      (println (fact 6))
+      (println (fact 7))
+      (println (fact 8))
+      (println (fact 9))
+      (println (fact 10))
+      (println (fact 11))
+      (println (fact 12))
+      (println (fact 13))
+      (println (fact 14))
+      (println (fact 15))
+      (println (fact 16))
+      (println (fact 17))
+      (println (fact 18))
+      (println (fact 19))
+      (println (fact 20))
 
       ;; print a pair of characters
-      (putc 42)
-      (putc 10)
+      ;(putc 42)
+      ;(putc 10)
+
+      ; create a cons cell, and print it :)
+      (println (cons 2 3 ))
 
       ;; return value is the last thing compiled.
       0

--- a/main.go
+++ b/main.go
@@ -590,10 +590,14 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 			"r9",
 		}
 
-		for i, a := range n.Args {
+		for _, a := range n.Args {
 			g.emitExpr(a, env)
+			g.emitln("    push rax")
+		}
+
+		for i := len(n.Args) - 1; i >= 0; i-- {
 			g.emitln(fmt.Sprintf(
-				"    mov %s, rax",
+				"    pop %s",
 				regs[i],
 			))
 		}

--- a/main.go
+++ b/main.go
@@ -635,6 +635,7 @@ func (g *Generator) emitRuntime() {
 	stdlib := `
 section .text
 
+;; Is the given value an integer?
 intp:
     mov rax, rdi
     and rax, 7
@@ -643,6 +644,7 @@ intp:
     movzx rax, al
     ret
 
+;; Is the given value a string?
 strp:
     mov rax, rdi
     mov rax, rdi
@@ -652,8 +654,7 @@ strp:
     movzx rax, al
     ret
 
-
-section .text
+;; Print an integer
 printint:
     push rbp
     mov rbp, rsp
@@ -680,19 +681,15 @@ convert_loop:             ;; build up ASCII via divisions
     leave
     ret
 
-section .data
-align 8
-newline_str:
-    db 10
-
-section .text
-
+;; terminate execution with the given exit-code
 exit:
     UNTAG_REG rdi
     mov rax, 60     ; sys_exit
     syscall
     ret
 
+
+;; print a newline.
 newline:
     mov rax, 1      ; SYS_write
     mov rdi, 1      ; stdout
@@ -701,15 +698,9 @@ newline:
     syscall
     ret
 
-
-section .data
-align 8
-putc_buffer:
-    db 10
-
-section .text
-
+;; Write the given ASCII character to stdout
 putc:
+    mov rax, rdi
     UNTAG_REG rax
     mov [putc_buffer],  al  ; store character
     mov rax, 1      ; SYS_write
@@ -719,7 +710,7 @@ putc:
     syscall
     ret
 
-; RDI = pointer to null-terminated string
+;; Print the given string.
 printstr:
     UNTAG_REG rdi
     push rdi
@@ -735,6 +726,31 @@ printstr:
     mov rdi, 1      ; stdout
     syscall
     ret
+
+
+section .data
+
+;; buffer for "\n", used by (newline)
+align 8
+newline_str:
+    db 10
+
+;; buffer for storing a single character, used by (putc x)
+align 8
+putc_buffer:
+    db 10
+
+;; zero section
+section .bss
+
+;; heap storage
+align 16
+heap:
+    resb 1048576
+
+;; offset used of our heap area.
+heap_ptr:
+    resq 1
 	`
 	g.emitln(stdlib)
 }
@@ -775,6 +791,9 @@ section .text
 	// Add our entry-point
 	entry := `
 _start:
+    mov rax, heap        ; setup our heap pointer
+    mov [heap_ptr], rax  ; cons cells are heap-allocated
+
     call main
     mov rdi, rax
     shr rdi, 1

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@
 // [X] INT?  // true if value is integer.
 // [X] STR?  // true if value is string.
 // [X] CONS? // true if value is cons
+// [X] NIL?  // true if value is nil
 //
 // Standard library:
 // [X] PRINTINT
@@ -32,12 +33,12 @@
 //
 //	000:  INT
 //	001:  STRING
-//      010:  ...
+//      010:  CONS
 //      011:  ...
 //      100:  ...
 //      101:  ...
 //      110:  ...
-//      111:  ...
+//      111:  NIL
 
 // ABI uses the Sys V style, so max six arguments:
 // arg0 -> rdi
@@ -75,6 +76,9 @@ type StringLiteral struct {
 }
 type Symbol struct {
 	Name string
+}
+
+type Nil struct {
 }
 
 type Call struct {
@@ -275,6 +279,10 @@ func (p *Parser) parseExpr() Expr {
 		return &Int{Value: n}
 	}
 
+	// nil?
+	if t == "nil" {
+		return &Nil{}
+	}
 	// symbol
 	return &Symbol{Name: t}
 }
@@ -437,6 +445,10 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 			offset,
 		))
 
+	case *Nil:
+		g.emitln("    mov rax, 0       ; NIL")
+		g.emitln("    TAG_NIL_REG rax  ; Tagged")
+
 	case *If:
 		elseLbl := g.label("else")
 		endLbl := g.label("endif")
@@ -482,7 +494,6 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 		g.emitExpr(n.Body, child)
 
 	case *Call:
-
 		if n.Fn == "<=" {
 			g.emitExpr(n.Args[0], env)
 			g.emitln("    UNTAG_REG rax")
@@ -554,16 +565,20 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 		// Rewrite a couple of functions, because
 		// nasm doesn't like their names as labels.
 		//
+		// We probably need a map with "old -> mappings" soon.
+		// Or could just change "trailing?" into "p".
+		//
 		if n.Fn == "int?" {
 			n.Fn = "intp"
 		}
-
 		if n.Fn == "str?" {
 			n.Fn = "strp"
 		}
-
 		if n.Fn == "cons?" {
 			n.Fn = "consp"
+		}
+		if n.Fn == "nil?" {
+			n.Fn = "nilp"
 		}
 
 		regs := []string{
@@ -669,6 +684,16 @@ consp:
     movzx rax, al
     ret
 
+;; Is the given value nil?
+nilp:
+    mov rax, rdi
+    mov rax, rdi
+    and rax, 7
+    cmp rax, 7
+    setz al
+    movzx rax, al
+    ret
+
 ;; Print an integer
 printint:
     push rbp
@@ -740,6 +765,7 @@ printstr:
     mov rax, 1      ; write
     mov rdi, 1      ; stdout
     syscall
+
     ret
 
 
@@ -820,6 +846,11 @@ func (g *Generator) Generate(defs []*Defun) string {
 %macro TAG_CONS_REG 1
     sal %1, 3
     or %1, 2
+%endmacro
+
+%macro TAG_NIL_REG 1
+    sal %1, 3
+    or %1, 7
 %endmacro
 
 %macro UNTAG_REG 1

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@
 // [X] LET
 // [X] INT?  // true if value is integer.
 // [X] STR?  // true if value is string.
+// [X] CONS? // true if value is cons
 //
 // Standard library:
 // [X] PRINTINT
@@ -561,6 +562,10 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 			n.Fn = "strp"
 		}
 
+		if n.Fn == "cons?" {
+			n.Fn = "consp"
+		}
+
 		regs := []string{
 			"rdi",
 			"rsi",
@@ -654,6 +659,16 @@ strp:
     movzx rax, al
     ret
 
+;; Is the given value a cons?
+consp:
+    mov rax, rdi
+    mov rax, rdi
+    and rax, 7
+    cmp rax, 2
+    setz al
+    movzx rax, al
+    ret
+
 ;; Print an integer
 printint:
     push rbp
@@ -728,6 +743,39 @@ printstr:
     ret
 
 
+;; Allocate space for a new cons area, return it in RAX
+;; 16-bytes; first has the CAR, second the CDR.
+cons:
+    mov rax, [heap_ptr]      ; get the value of the heap pointer
+    add qword [heap_ptr], 16 ; bump it by 2x ptrs
+    mov [rax], rdi           ; store first item
+    mov [rax+8], rsi         ; second item
+    TAG_CONS_REG rax         ; return the tagged allocation
+    ret
+
+;; Get the first item in the cons.
+car:
+    mov rbx, rdi
+    and rbx, 7
+    cmp rbx, 2
+    jne type_error
+    UNTAG_REG rdi
+    mov rax, [rdi]
+    ret
+
+;; Get the second item in the cons.
+cdr:
+    mov rbx, rdi
+    and rbx, 7
+    cmp rbx, 2
+    jne type_error
+    UNTAG_REG rdi
+    mov rax, [rdi + 8]
+    ret
+
+type_error:
+    jmp exit
+
 section .data
 
 ;; buffer for "\n", used by (newline)
@@ -767,6 +815,11 @@ func (g *Generator) Generate(defs []*Defun) string {
 %macro TAG_STRING_REG 1
     sal %1, 3
     or %1, 1
+%endmacro
+
+%macro TAG_CONS_REG 1
+    sal %1, 3
+    or %1, 2
 %endmacro
 
 %macro UNTAG_REG 1


### PR DESCRIPTION
This is a bit rough and ready but we've added:

* trivial heap allocator
* the ability to create a pair with (cons x y)
* The ability to recognize a cons pair.
* The ability to create/use nil (both `nil` and `(nil? x)`).
* This allows us to create and print cons pairs properly, recursively.

We're gonna be screwed for creating list items like this, since we only have six registers in the SysV ABI without spilling..  Life is hard.

But I think this closes #6.