### PR TITLE
Correctly return values from tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ Given a lisp-program output the assembly version of that program, which may be c
       0)
 ```
 
-See [example.lisp](example.lisp) for a genuine/bigger example, including a more complex `print` definition that understands `nil` and cons pairs.
+See [example.lisp](example.lisp) for a genuine/bigger example, including a more complex `print` definition that understands `nil` and cons pairs, as well as applying functions to lists.
 
 
 
 ## Features
 
 * Support for functions, bindings, and basic mathematical operations.
+* A rough and ready bump-allocator for easy heap-allocated cons-cells.
 * Support for integers, nil, strings and cons pairs.
   * We have some run-time type detection via functions
     * `(cons? x)` - True if the item is a cons pair.
@@ -54,17 +55,23 @@ See [example.lisp](example.lisp) for a genuine/bigger example, including a more 
     * `(nil? x)` - True if the item is nil.
     * `(str? y)` - True if the item is a string.
 * Primitives
-  * `(printint 3)` - prints the given number to STDOUT.
-  * `(printstr "Steve")` - prints the given string to STDOUT.
+  * `(exit N)` - Exit with the given status-code.
+  * `(printint N)` - prints the given number to STDOUT.
+  * `(printstr STR)` - prints the given string to STDOUT.
   * `(newline)` - prints a newline.
   * `(putc 42)` - write the given ASCII character to STDOUT.
+* Special forms
+  * `(do ..)`
+  * `(if ..)`
+  * `(let ..)`
+  * `(list ..)`
 
 Anti-features:
 
-* No true lists, just cons pairs
 * No lambdas
 * No closures.
 * No "setq" or "set!" for global variables.
+  * You want a named variable?  Use `let`.
 
 
 
@@ -84,4 +91,4 @@ Finally execute your program:
 
     ./example
 
-`make test` will ensure everything happens correctly for our [example.lisp](example.lisp) file.
+`make clean test` will ensure everything happens correctly for our [example.lisp](example.lisp) file.

--- a/example.lisp
+++ b/example.lisp
@@ -18,25 +18,50 @@
        (putc 41)       ; )
        )))
 
+;; exactly like print, but with a newline on the end.
 (defun println (x)
   (print x)
   (newline))
 
-;; Add one to the argument
+;; Add one to the given argument.
 (defun add1 (x)
   (+ x 1))
 
-;; double the argument
+;; double the given argument
 (defun double (x)
   (* x 2))
 
-;; square the argument
+;; square the given argument
 (defun square (x)
   (* x x))
 
-;; factorial.  woo.
+;; factorial.  woo!
 (defun fact (n)
   (if (<= n 1) 1 (* n (fact (- n 1)))))
+
+;; print the factorial of every number in the given list
+(defun factorials (xs)
+  (if xs
+      (do
+        (print "factorial ")
+        (print (car xs))
+        (print ": ")
+        (println (fact (car xs)))
+        (factorials (cdr xs)))
+      ))
+
+;; count the length of the given list
+(defun length (xs)
+  (if xs
+      (+ 1 (length (cdr xs)))
+      0))
+
+;; sum all the numbers in the list
+(defun sum (xs)
+  (if xs
+      (+ (car xs)
+         (sum (cdr xs)))
+      0))
 
 ;; Setup a binding for "X" to be a function-result.
 ;; Setup Y for a literal.
@@ -44,16 +69,20 @@
 (defun main ()
   (let ((x (double 13)) (y 12))
     (do
+
+     (if nil
+         (do
+          (println "BUG: nil should not be true.  Terminating")
+          (exit 1)))
+
      (if 1
-         (println "Hello, I am if!"))
+         (println "Hello, I am a working `if` statement!"))
 
       (println "Hello World!")
-      (println "I am compiled lisp.  kinda.")
-      (println "Some random maths")
-       ;; print 12 * 12 -> 144
-      (println (square y))
+      (println "I am compiled lisp")
 
-      ;; print 13 * 2 * 2 -> 52.
+      (println "Some random maths")
+      (println (square y))
       (println (double x))
 
       ;; little countdown to test maths
@@ -81,33 +110,21 @@
       (println (- 98 98))
 
       ;; now some factorials.
-      (println "Showing results of factorial - 1-20")
-      (println (fact 1))
-      (println (fact 2))
-      (println (fact 3))
-      (println (fact 4))
-      (println (fact 5))
-      (println (fact 6))
-      (println (fact 7))
-      (println (fact 8))
-      (println (fact 9))
-      (println (fact 10))
-      (println (fact 11))
-      (println (fact 12))
-      (println (fact 13))
-      (println (fact 14))
-      (println (fact 15))
-      (println (fact 16))
-      (println (fact 17))
-      (println (fact 18))
-      (println (fact 19))
-      (println (fact 20))
+      (println "Showing results of factorial - 1-10:")
+      (factorials (list 1 2 3 4 5 6 7 8 9 10))
+
+      (print "The length of the list of numbers we printed is:" )
+      (println (length (list 1 2 3 4 5 6 7 8 9 10)))
+
 
       ;; print a pair of characters
       ;(putc 42)
       ;(putc 10)
 
       (println nil)
+
+      (print "Summing numbers 1..10: ")
+      (println (sum (list 1 2 3 4 5 6 7 8 9 10)))
 
       ; create a cons cell, and print it :)
       (println (cons (cons (cons 12 31) 392) nil))

--- a/main.go
+++ b/main.go
@@ -260,6 +260,22 @@ func (p *Parser) parseDefun() *Defun {
 	}
 }
 
+// buildList is used to turn "(list 1 2 3)" into "(cons 1 (cons 2 (cons 3 nil)))"
+func (p *Parser) buildList(args []Expr) Expr {
+	result := Expr(&Nil{})
+
+	for i := len(args) - 1; i >= 0; i-- {
+		result = &Call{
+			Fn: "cons",
+			Args: []Expr{
+				args[i],
+				result,
+			},
+		}
+	}
+
+	return result
+}
 func (p *Parser) parseExpr() Expr {
 	t := p.peek()
 
@@ -349,6 +365,17 @@ func (p *Parser) parseList() Expr {
 			Bindings: binds,
 			Body:     body,
 		}
+
+	case "list":
+		var args []Expr
+
+		for p.peek() != ")" {
+			args = append(args, p.parseExpr())
+		}
+
+		p.expect(")")
+
+		return p.buildList(args)
 
 	default:
 		var args []Expr
@@ -455,8 +482,9 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 
 		g.emitExpr(n.Cond, env)
 
-		g.emitln("    cmp rax, 0")
-		g.emitln("    je " + elseLbl)
+		g.emitln("    and rax, 7    ; get type bits")
+		g.emitln("    cmp rax, 7    ; is this a nil?")
+		g.emitln("    jz " + elseLbl)
 
 		g.emitExpr(n.Then, env)
 
@@ -501,10 +529,7 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 			g.emitExpr(n.Args[1], env)
 			g.emitln("    UNTAG_REG rax")
 			g.emitln("    pop rbx")
-			g.emitln("    cmp rbx, rax")
-			g.emitln("    setle al")
-			g.emitln("    movzx rax, al")
-			g.emitln("    TAG_INTEGER_REG rax")
+			g.emitln("    call lt_equals")
 			return
 		}
 
@@ -664,38 +689,67 @@ intp:
     mov rax, rdi
     and rax, 7
     cmp rax, 0
-    setz al
-    movzx rax, al
+    jnz .nil
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+.nil:
+    mov rax, 0
+    TAG_NIL_REG rax
     ret
 
 ;; Is the given value a string?
 strp:
     mov rax, rdi
-    mov rax, rdi
     and rax, 7
     cmp rax, 1
-    setz al
-    movzx rax, al
+    jnz .nil
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+.nil:
+    mov rax, 0
+    TAG_NIL_REG rax
     ret
 
 ;; Is the given value a cons?
 consp:
     mov rax, rdi
-    mov rax, rdi
     and rax, 7
     cmp rax, 2
-    setz al
-    movzx rax, al
+    jnz .nil
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+.nil:
+    mov rax, 0
+    TAG_NIL_REG rax
     ret
 
 ;; Is the given value nil?
 nilp:
     mov rax, rdi
-    mov rax, rdi
     and rax, 7
     cmp rax, 7
-    setz al
-    movzx rax, al
+    jnz .nil
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+.nil:
+    mov rax, 0
+    TAG_NIL_REG rax
+    ret
+
+;; <=
+lt_equals:
+    cmp rbx, rax
+    jle .true
+    mov rax, 0
+    TAG_NIL_REG rax
+    ret
+.true:
+    mov rax, 1
+    TAG_INTEGER_REG rax
     ret
 
 ;; Print an integer


### PR DESCRIPTION
Instead of returning 0/1 we now return 1, typed as an integer, or nil from the <= function - as well as nil? str? int? etc.

We've added a "fake list" support so:

```
    (list 1 2 3 ..)
```

becomes:

```
    (cons 1 (cons 2 (cons 3 nil)))
```

Which is nice.  This is demonstrated in a few functions that process every element of a list (summing values, or printing their factories, etc).

This closes #8.