### PR TITLE
Implement the missing comparison operators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Anti-features:
 
 * No lambdas
 * No closures.
-* No "setq" or "set!" for global variables.
+* No "set!" for global variables.
   * You want a named variable?  Use `let`.
 
 

--- a/example.lisp
+++ b/example.lisp
@@ -116,20 +116,39 @@
       (print "The length of the list of numbers we printed is:" )
       (println (length (list 1 2 3 4 5 6 7 8 9 10)))
 
-
-      ;; print a pair of characters
-      ;(putc 42)
-      ;(putc 10)
-
-      (println nil)
-
       (print "Summing numbers 1..10: ")
       (println (sum (list 1 2 3 4 5 6 7 8 9 10)))
 
+      ;; Test the comparison operators.
+      ;; They return 1 (int) or NIL depending on whether they are true or not
+      (print "(< 3 4):")
+      (print (< 3 4))
+      (print " (< 4 4):")
+      (println (< 4 4))
+
+      (print "(> 3 4):")
+      (print (> 3 4))
+      (print " (> 34 4):")
+      (println (> 34 4))
+
+      (print "(>= 3 4):")
+      (print (>= 3 4))
+      (print " (>= 4 4):")
+      (print (>= 4 4))
+      (print " (>= 34 4):")
+      (println (>= 34 4))
+
+      (print "(<= 3 4):")
+      (print (<= 3 4))
+      (print " (<= 4 4):")
+      (print (<= 4 4))
+      (print " (<= 34 4):")
+      (println (<= 34 4))
+
       ; create a cons cell, and print it :)
       (println (cons (cons (cons 12 31) 392) nil))
-
       (println (cons 1 (cons 2 (cons 3 nil))))
+
       ;; return value is the last thing compiled.
       0
       ;; You can be more explicit with (exit 0)

--- a/main.go
+++ b/main.go
@@ -8,9 +8,9 @@
 // [X] *
 // [X] /
 // [X] <=
-// [ ] <
-// [ ] >
-// [ ] >=
+// [X] <
+// [X] >
+// [X] >=
 //
 // Special forms
 // [X] DEFUN
@@ -533,6 +533,39 @@ func (g *Generator) emitExpr(e Expr, env *Env) {
 			return
 		}
 
+		if n.Fn == "<" {
+			g.emitExpr(n.Args[0], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    push rax")
+			g.emitExpr(n.Args[1], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    pop rbx")
+			g.emitln("    call lt")
+			return
+		}
+
+		if n.Fn == ">" {
+			g.emitExpr(n.Args[0], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    push rax")
+			g.emitExpr(n.Args[1], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    pop rbx")
+			g.emitln("    call gt")
+			return
+		}
+
+		if n.Fn == ">=" {
+			g.emitExpr(n.Args[0], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    push rax")
+			g.emitExpr(n.Args[1], env)
+			g.emitln("    UNTAG_REG rax")
+			g.emitln("    pop rbx")
+			g.emitln("    call gt_equals")
+			return
+		}
+
 		if n.Fn == "+" {
 			g.emitExpr(n.Args[0], env)
 			g.emitln("    UNTAG_REG rax")
@@ -744,6 +777,42 @@ nilp:
 lt_equals:
     cmp rbx, rax
     jle .true
+    mov rax, 0
+    TAG_NIL_REG rax
+    ret
+.true:
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+
+;; >=
+gt_equals:
+    cmp rbx, rax
+    jge .true
+    mov rax, 0
+    TAG_NIL_REG rax
+    ret
+.true:
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+
+;; <
+lt:
+    cmp rbx, rax
+    jl .true
+    mov rax, 0
+    TAG_NIL_REG rax
+    ret
+.true:
+    mov rax, 1
+    TAG_INTEGER_REG rax
+    ret
+
+;; >
+gt:
+    cmp rbx, rax
+    jg .true
     mov rax, 0
     TAG_NIL_REG rax
     ret


### PR DESCRIPTION
This pull-request adds ">=", ">" and "<".  Like the existing <= these either return the integer 1, or the NIL value, depending on whether the comparison is true or not.

There is a lot of repetition here, but that's a job for future-Steve.

This closes #3.