### PR TITLE
Added lisp-based standard library to our compiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/tmp.asm
 test/*.test
 test/*.out
 test/*.s
+test/*.o

--- a/README.md
+++ b/README.md
@@ -30,40 +30,35 @@ Already this compiler is more "real" and "usable", although it lacks the quality
 ## Example
 
 ```lisp
-     ;; if the value is a number?  print it as an integer.
-     ;; otherwise print it as a string
-     (defun print (x)
-       (if (int? x)
-          (printint x)
-         (do
-           (printstr x)
-           (newline))))
+    ;; factorial.  woo.
+    (defun fact (n)
+      (if (<= n 1) 1 (* n (fact (- n 1)))))
 
-     ;; factorial.  woo.
-     (defun fact (n)
-       (if (<= n 1) 1 (* n (fact (- n 1)))))
-
+    ;; entry-point
     (defun main ()
       ;; now some factorials.
-      (print "Showing results of factorial - 1-20")
+      (print "Showing results of factorial")
       (print (fact 1))
       (print (fact 2))
       (print (fact 3))
       (print (fact 4))
       (print (fact 5))
-      (print (fact 6))
-      (print (fact 7))
-      (print (fact 8))
-      (print (fact 9))
+      ;; ..
       (print (fact 10))
 
       ;; exit code - use "(exit 3)" if you prefer
       0)
 ```
 
-See [example.lisp](example.lisp) for a genuine/bigger example, including a more complex `print` definition that understands `nil` and cons pairs, as well as applying functions to lists.
+See [example.lisp](example.lisp) for a genuine/bigger example.
 
-See the [test/](test/) directory for some test-cases which demonstrate specific things.
+We prepend a standard library of functions, implemented in lisp, to all user programs unless `-stdlib=false` is added to the command line.  That library itself is a useful reference/demonstration of functionality:
+
+* [stdlib.lisp](stdlib.lisp) - Our lisp standard library.
+  * Has a flexible `print` definition.
+  * Has `map`, `length` and similar general-purpose functions.
+
+Finally our [test/](test/) directory contains test-cases which demonstrate specific things.
 
 
 

--- a/example.lisp
+++ b/example.lisp
@@ -4,37 +4,6 @@
 ;;
 ;;
 
-;; Print the given item intelligently.
-(defun print (x)
-  (if (int? x)
-      (printint x))
-  (if (nil? x)
-      (printstr "<nil>"))
-  (if (str? x)
-      (printstr x))
-  (if (cons? x)
-      (do
-       (putc 40)      ; "("
-       (printcons x)  ; List items, separated by spaces
-        (putc 41)     ; ")"
-      )))
-
-(defun printcons (x)
-  (print (car x))
-  (if (nil? (cdr x))
-      nil
-      (if (cons? (cdr x))
-          (do
-            (putc 32)
-            (printcons (cdr x)))
-          (do
-            (printstr " . ")
-            (print (cdr x))))))
-
-;; exactly like print, but with a newline on the end.
-(defun println (x)
-  (print x)
-  (newline))
 
 ;; print every item in a list.
 (defun print_list (xs)
@@ -72,27 +41,6 @@
        (print_list_ln (list "factorial " (car xs) ": " (fact (car xs))))
         (factorials (cdr xs)))
       ))
-
-;; Create a new list by calling the given function for every list element
-(defun map (fn lst)
-  (if (nil? lst)
-      nil
-      (cons
-        (fn (car lst))
-        (map fn (cdr lst)))))
-
-;; count the length of the given list
-(defun length (xs)
-  (if xs
-      (+ 1 (length (cdr xs)))
-      0))
-
-;; sum all the numbers in the list
-(defun sum (xs)
-  (if xs
-      (+ (car xs)
-         (sum (cdr xs)))
-      0))
 
 ;; Setup a binding for "X" to be a function-result.
 ;; Setup Y for a literal.

--- a/main.go
+++ b/main.go
@@ -51,11 +51,16 @@
 package main
 
 import (
+	_ "embed"
+	"flag"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 )
+
+//go:embed stdlib.lisp
+var stdlibLisp string
 
 //
 // AST
@@ -1270,20 +1275,30 @@ _start:
 // main
 func main() {
 
-	if len(os.Args) != 2 {
-		fmt.Println("usage: slisp file.lisp")
+	// CLI flags
+	stdlib := flag.Bool("stdlib", true, "Prepend our Lisp standard library to user-programs")
+	flag.Parse()
+
+	// Do we have a file?
+	if len(flag.Args()) != 1 {
+		fmt.Println("usage: slisp [-stdlib=false] file.lisp")
 		os.Exit(1)
 	}
 
 	// Read the file-contents
-	data, err := os.ReadFile(os.Args[1])
+	data, err := os.ReadFile(flag.Args()[0])
 	if err != nil {
 		fmt.Printf("failed to read input %s: %s\n", os.Args[1], err)
 		return
 	}
 
+	prg := string(data)
+	if *stdlib {
+		prg = stdlibLisp + "\n" + prg
+	}
+
 	// Parse into functions
-	defs := parseProgram(string(data))
+	defs := parseProgram(prg)
 
 	// Generate the code, and print it
 	g := &Generator{}

--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -1,0 +1,56 @@
+;;; stdlib.lisp - Lisp standard library, prepended to user programs.
+
+
+;; print the given item intelligently.
+(defun print (x)
+  (if (int? x)
+      (printint x))
+  (if (nil? x)
+      (printstr "<nil>"))
+  (if (str? x)
+      (printstr x))
+  (if (cons? x)
+      (do
+       (putc 40)      ; "("
+       (printcons x)  ; List items, separated by spaces
+        (putc 41)     ; ")"
+      )))
+
+(defun printcons (x)
+  (print (car x))
+  (if (nil? (cdr x))
+      nil
+      (if (cons? (cdr x))
+          (do
+            (putc 32)
+            (printcons (cdr x)))
+          (do
+            (printstr " . ")
+            (print (cdr x))))))
+
+;; exactly like print, but with a newline on the end.
+(defun println (x)
+  (print x)
+  (newline))
+
+
+;; Create a new list by calling the given function for every list element
+(defun map (fn lst)
+  (if (nil? lst)
+      nil
+      (cons
+        (fn (car lst))
+        (map fn (cdr lst)))))
+
+;; count the length of the given list
+(defun length (xs)
+  (if xs
+      (+ 1 (length (cdr xs)))
+      0))
+
+;; sum all the numbers in the list
+(defun sum (xs)
+  (if xs
+      (+ (car xs)
+         (sum (cdr xs)))
+      0))

--- a/test/compare.lisp
+++ b/test/compare.lisp
@@ -1,11 +1,3 @@
-(defun print (x)
-  (if (str? x)
-      (printstr x))
-  (if (nil? x)
-      (printstr "<nil>"))
-  (if (int? x)
-      (printint x)))
-
 ;; Test the comparison operators.
 ;; They return 1 (int) or NIL depending on whether they are true or not
 (defun main ()

--- a/test/print.lisp
+++ b/test/print.lisp
@@ -1,35 +1,4 @@
-;; Print the given item intelligently.
-(defun print (x)
-  (if (int? x)
-      (printint x))
-  (if (nil? x)
-      (printstr "<nil>"))
-  (if (str? x)
-      (printstr x))
-  (if (cons? x)
-      (do
-       (putc 40)      ; "("
-       (printcons x)  ; List items, separated by spaces
-        (putc 41)     ; ")"
-      )))
-
-(defun printcons (x)
-  (print (car x))
-  (if (nil? (cdr x))
-      nil
-      (if (cons? (cdr x))
-          (do
-            (putc 32)
-            (printcons (cdr x)))
-          (do
-            (printstr " . ")
-            (print (cdr x))))))
-
-;; exactly like print, but with a newline on the end.
-(defun println (x)
-  (print x)
-  (newline))
-
+;
 (defun main ()
   (println (cons 1 2))
   (println (cons 1 (cons 2 nil)))


### PR DESCRIPTION
We embed the contents of `stdlib.lisp` to the user-input, unless told not to, and that means we no longer need to copy/paste the `print` function in our tests, etc.

This is now documented, and closes #22.