### PR TITLE
Allow strings to have \t, \n, etc.

### DIFF
--- a/main.go
+++ b/main.go
@@ -915,7 +915,7 @@ func (g *Generator) Generate(defs []*Defun) string {
 	for _, s := range g.strings {
 		g.emitln("align 8")
 		g.emitln(s.Label + ":")
-		g.emitln(fmt.Sprintf("     db \"%s\", 0", s.Value))
+		g.emitln(fmt.Sprintf("     db `%s`, 0", s.Value))
 	}
 	stringTable = g.text.String()
 	g.text.Reset()

--- a/test/escapes.lisp
+++ b/test/escapes.lisp
@@ -1,0 +1,4 @@
+;;; prove that "\t", "\n", etc, work
+
+(defun main()
+  (print "This is a string.\n\t1\t2\n\t3\t4\n\nOK!"))

--- a/test/escapes.test.expected
+++ b/test/escapes.test.expected
@@ -1,0 +1,5 @@
+This is a string.
+	1	2
+	3	4
+
+OK!


### PR DESCRIPTION
According the nasm manual you need to use backquotes to get this, so it was a trivial change, this :

         str1: db "abcd\n"

Just needs to be:

         str1: db `abcd\n`

This closes #15, and adds a test-case to prove it works.