### PR TITLE
Implement `chr` and `ord`

### DIFF
--- a/template.tmpl
+++ b/template.tmpl
@@ -398,6 +398,30 @@ printstr:
     ret
 
 
+;; chr - convert an integer to a character
+chr:
+    mov rbx, rdi
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_INTEGER
+    jne type_error
+    UNTAG_REG rdi
+    mov rax, rdi
+    and rax, 0xFF        ; Only 0-255 is ASCII
+    TAG_CHAR_REG rax
+    ret
+
+
+;; ord - convert a character to an integer.
+ord:
+    mov rbx, rdi
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_CHAR
+    jne type_error
+    UNTAG_REG rdi
+    mov rax, rdi
+    TAG_INTEGER_REG rax
+    ret
+
 ;; Allocate space for a new cons cell, return it in RAX.
 ;;
 ;; 16-bytes; first has the CAR, second the CDR.

--- a/test/char.lisp
+++ b/test/char.lisp
@@ -14,4 +14,20 @@
     (newline)
     (print "Character again: ")
     (putc (+ a 1))
-    (newline)))
+    (newline))
+
+
+  (putc (chr 42))
+  (putc (chr 32))
+  (putc (chr 42))
+  (putc #\\n)
+
+  (print "The ASCII for 'x' is:")
+  (print (ord #\x))
+  (newline)
+
+  (print "The integer 41 is :")
+  (print (chr 41))
+  (newline)
+
+  )

--- a/test/char.test.expected
+++ b/test/char.test.expected
@@ -3,3 +3,6 @@
 Character: a
 Number:98
 Character again: b
+* *
+The ASCII for 'x' is:120
+The integer 41 is :)


### PR DESCRIPTION
These do "int -> char" and "char -> int", respectively.  They will exit execution on type-errors.

This closes #35.