### PR TITLE
Support arbitrary bases for numbers

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -10,8 +10,10 @@ Primitive types work as you would expect:
 
 * Comments are begun with ";" and continue until the end of the line.
   * There are no block comments.
-* Numbers are written as integers:
+* We only support integers, but they may be written in any base the golang `strconv.ParseInt` function supports:
   * `(print 3)`
+  * `(print 0xff)`
+  * `(print 0b10101010)`
 * Floating point numbers are not supported, so this is an error:
   * `(print 3.4)`
 * Strings are just encoded literally, and escaped characters are honored:

--- a/main.go
+++ b/main.go
@@ -350,7 +350,7 @@ func (p *Parser) parseExpr() Expr {
 	}
 
 	// integer
-	if n, err := strconv.ParseInt(t, 10, 64); err == nil {
+	if n, err := strconv.ParseInt(t, 0, 64); err == nil {
 		return &Int{Value: n}
 	}
 

--- a/test/maths.lisp
+++ b/test/maths.lisp
@@ -38,7 +38,7 @@
       (newline)
 
       ;; 1
-      (printint (- 3 2))
+      (printint (- 0xFF 0b11111110))
       (newline)
 
       ;; 0


### PR DESCRIPTION
Now we support 0xFF and 0b10101010, etc.  Basically we let the golang strconv.ParseInt to determine the base automatically rather than assuming base 10.