### PR TITLE
Implement `strlen` and `strcmp` 

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -88,6 +88,8 @@ Core primitives are implemented in assembly language, and can be found within th
     * Return a list of numbers between the given start/end, using the specified step-size.
   * `seq`
     * Return a list of numbers from 0 to N.
+  * `strlen`
+    * Return the length of the given string.
 
 
 
@@ -100,7 +102,7 @@ The implementation of these primitives can be found in the file [stdlib.slisp](s
 * `abs`
   * Return the absolute value of the given integer.  (e.g. 3 -> 3, and -3 -> 3).
 * `length`
-  * Return the length of the specified list.
+  * Return the length of the specified list, or string.
 * `map`
   * Create a new list by calling the given function over every element of the supplied list.
 * `print`

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -88,6 +88,8 @@ Core primitives are implemented in assembly language, and can be found within th
     * Return a list of numbers between the given start/end, using the specified step-size.
   * `seq`
     * Return a list of numbers from 0 to N.
+  * `strcmp`
+    * Compare the two given strings, like the C-function this returns zero on equality.
   * `strlen`
     * Return the length of the given string.
 

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -50,11 +50,13 @@
         (fn (car lst))
         (map fn (cdr lst)))))
 
-;; count the length of the given list
+;; Return the length of the given list or string
 (defun length (xs)
-  (if xs
-      (+ 1 (length (cdr xs)))
-      0))
+  (if (str? xs)
+    (strlen xs)
+    (if xs
+        (+ 1 (length (cdr xs)))
+        0)))
 
 ;; sum all the numbers in the list
 (defun sum (xs)

--- a/template.tmpl
+++ b/template.tmpl
@@ -581,6 +581,26 @@ fn_implode:
     TAG_STRING_REG rax
     ret
 
+
+;; Find the length of the given string.
+fn_strlen:
+    mov rbx, rdi
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+
+    UNTAG_REG rdi
+    xor rax, rax
+.find:
+    cmp byte [rdi], 0
+    je .found_end
+    inc rdi
+    inc rax
+    jmp .find
+.found_end:
+    TAG_INTEGER_REG rax
+    ret
+
 section .data
 
 ;; buffer for "\n", used by (newline)

--- a/template.tmpl
+++ b/template.tmpl
@@ -601,6 +601,39 @@ fn_strlen:
     TAG_INTEGER_REG rax
     ret
 
+;; Compare the two specified strings.
+fn_strcmp:
+    mov rbx, rdi             ; type-check arg1
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+    mov rbx, rsi             ; type-check arg2
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+
+    UNTAG_REG rdi
+    UNTAG_REG rsi
+
+.strcmp_next_char:
+    mov al, byte [rdi]
+    cmp al, byte [rsi]
+    jne .strcmp_diff
+    test al, al
+    je .strcmp_done
+    inc rdi
+    inc rsi
+    jmp .strcmp_next_char
+.strcmp_diff:
+    movzx rdx, byte [rsi]
+    sub al, dl
+.strcmp_done:
+    movsx rax, al            ; Truncate, but keep the sign
+    TAG_INTEGER_REG rax
+    ret
+
+
+
 section .data
 
 ;; buffer for "\n", used by (newline)

--- a/template.tmpl
+++ b/template.tmpl
@@ -270,8 +270,22 @@ equals:
     GET_TAG_BITS rax     ; type of arg
     cmp rax, rbx
     jnz .nil         ; different types?  Then not equal
+
+    ; If one of the types is a string then we know both are.
+    ; RSI/RDI will still have their original values so we can
+    ; call strcmp.  If the value is 0 we know they are equal
+    cmp rax, TAG_ID_STRING
+    jnz .not_strings
+    call fn_strcmp
+    UNTAG_REG rax
+    cmp rax, 0
+    jz .equal
+    jmp .nil
+
+.not_strings:
     cmp rdi, rsi     ; same types, so compare the values directly
     jnz .nil
+.equal:
     mov rax, 1
     TAG_INTEGER_REG rax
     ret

--- a/test/string.lisp
+++ b/test/string.lisp
@@ -9,8 +9,12 @@
   (print a)
   (print " with b:")
   (print b)
-  (print " result: ")
-  (println (strcmp a b)))
+  (print " (strcmp a b): ")
+  (print (strcmp a b))
+  (print " (= a b): ")
+  (print (= a b))
+  (newline)
+  )
 
 
 (defun main ()

--- a/test/string.lisp
+++ b/test/string.lisp
@@ -1,0 +1,12 @@
+(defun showLen (x)
+  (print "The length of : '")
+  (print x)
+  (print "' is ")
+  (println (strlen x)))
+
+(defun main ()
+  "Test strlen/strcmp"
+
+  (showLen "Steve")
+  (showLen "")
+  )

--- a/test/string.lisp
+++ b/test/string.lisp
@@ -4,9 +4,25 @@
   (print "' is ")
   (println (strlen x)))
 
+(defun showCmp( a b )
+  (print "comparing a:")
+  (print a)
+  (print " with b:")
+  (print b)
+  (print " result: ")
+  (println (strcmp a b)))
+
+
 (defun main ()
   "Test strlen/strcmp"
 
+  ; strlen test
   (showLen "Steve")
   (showLen "")
-  )
+
+  ; strcmp test
+  (showCmp "Steve" "Steve")
+  (showCmp "Steve" "Rteve")
+
+  ; These should be identical
+  (showCmp "Hello" (implode (explode "Hello"))))

--- a/test/string.test.expected
+++ b/test/string.test.expected
@@ -1,2 +1,5 @@
 The length of : 'Steve' is 5
 The length of : '' is 0
+comparing a:Steve with b:Steve result: 0
+comparing a:Steve with b:Rteve result: 1
+comparing a:Hello with b:Hello result: 0

--- a/test/string.test.expected
+++ b/test/string.test.expected
@@ -1,5 +1,5 @@
 The length of : 'Steve' is 5
 The length of : '' is 0
-comparing a:Steve with b:Steve result: 0
-comparing a:Steve with b:Rteve result: 1
-comparing a:Hello with b:Hello result: 0
+comparing a:Steve with b:Steve (strcmp a b): 0 (= a b): 1
+comparing a:Steve with b:Rteve (strcmp a b): 1 (= a b): <nil>
+comparing a:Hello with b:Hello (strcmp a b): 0 (= a b): 1

--- a/test/string.test.expected
+++ b/test/string.test.expected
@@ -1,0 +1,2 @@
+The length of : 'Steve' is 5
+The length of : '' is 0


### PR DESCRIPTION
This pull-request adds two new primitives `strlen` and `strcmp`, which behave as the C-standard library would.

Using the new `strcmp` function I've updated the `=` function to test strings specially, and no longer rely upon interning for the result.

Documentation added, and test-cases.

This closes #48.