### PR TITLE
Make the env-package own the offsets.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -332,6 +332,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 				panic("capture not found: " + cap)
 			}
 
+			g.emitln("; copy capture " + cap)
 			g.emitln(fmt.Sprintf(
 				"    mov rcx, [rbp-%d]",
 				offset,
@@ -355,8 +356,6 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		// create a new child environment
 		child := env.New(ev)
 
-		nextSlot := child.CountLocals()
-
 		// populate the new environment
 		for _, b := range n.Bindings {
 
@@ -365,16 +364,12 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 				return err
 			}
 
-			offset := (nextSlot + 1) * 8
-
-			child.Define(b.Name, offset)
+			offset := child.Define(b.Name)
 
 			g.emitln(fmt.Sprintf(
 				"    mov [rbp-%d], rax",
 				offset,
 			))
-
-			nextSlot++
 		}
 
 		// compile each expression within the body
@@ -473,9 +468,8 @@ func (g *Compiler) emitDefun(fn *parser.Defun) error {
 	}
 
 	for i, p := range fn.Params {
-		offset := (i + 1) * 8
 
-		ev.Define(p, offset)
+		offset := ev.Define(p)
 
 		g.emitln(fmt.Sprintf(
 			"    mov [rbp-%d], %s",
@@ -521,9 +515,8 @@ func (g *Compiler) emitLambda(l *parser.Lambda) error {
 	}
 
 	for i, p := range l.Params {
-		offset := (i + 1) * 8
 
-		lambdaEnv.Define(p, offset)
+		offset := lambdaEnv.Define(p)
 
 		g.emitln(fmt.Sprintf(
 			"    mov [rbp-%d], %s",
@@ -533,8 +526,8 @@ func (g *Compiler) emitLambda(l *parser.Lambda) error {
 	}
 
 	// define captured variables, relative to our R15 pointer.
-	for i, cap := range l.Captures {
-		lambdaEnv.DefineCapture(cap, 8*(i+1))
+	for _, cap := range l.Captures {
+		lambdaEnv.DefineCapture(cap)
 	}
 
 	for _, xpr := range l.Exprs {

--- a/env/env.go
+++ b/env/env.go
@@ -25,24 +25,30 @@ func New(parent *Env) *Env {
 	}
 }
 
-// Define defines a local variable, in this case
-// the offset is relative to the RBP register.
-func (e *Env) Define(name string, offset int) {
+// Define defines a local variable, and returns the offset relative to the RBP register.
+func (e *Env) Define(name string) int {
+	offset := (e.countLocals() + 1) * 8
 	e.slots[name] = offset
+	return offset
 }
 
-// DefineCapture defines a captured variable, in this case
-// the offset is relative to the R15 closure-base register.
-func (e *Env) DefineCapture(name string, offset int) {
+// DefineCapture defines a captured variable, in this case the offset returned will be used
+// relative to the R15 closure-base register.
+func (e *Env) DefineCapture(name string) int {
+	offset := (len(e.captures) + 1) * 8
 	e.captures[name] = offset
+	return offset
 }
 
-func (e *Env) CountLocals() int {
-	ours := len(e.slots)
+// countLocals returns the number of local variables defined in this,
+// and any parent scopes.  It is necessary to calculate the offset to
+// use for stack-local addressing.
+func (e *Env) countLocals() int {
+	used := len(e.slots)
 	if e.parent != nil {
-		ours += e.parent.CountLocals()
+		used += e.parent.countLocals()
 	}
-	return ours
+	return used
 }
 
 // Names returns all the names of variables known at this level,

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -10,22 +10,14 @@ func TestBasic(t *testing.T) {
 	// create env
 	e := New(nil)
 
-	// should be empty
-	if e.CountLocals() != 0 {
-		t.Fatalf("empty env had local variables, which is wrong")
-	}
-
-	// but define a new value and that's oka
-	e.Define("foo", 3)
-	e.DefineCapture("cat", 1)
-	if e.CountLocals() != 1 {
-		t.Fatalf("incorrect local-count")
-	}
+	// will be empty - define things
+	e.Define("foo")
+	e.DefineCapture("cat")
 
 	// create a child
 	c := New(e)
-	c.Define("meow", 3)
-	c.DefineCapture("dog", 391)
+	c.Define("meow")
+	c.DefineCapture("dog")
 
 	// We now have two slots used.
 	out := c.Names()


### PR DESCRIPTION
We previously let the compiler own the slack-slots, (i.e offsets against the frame-pointer, or lambda base register R15), because that made sense when everything was in one package.

We split things up into separate packages in #51, and I noted there:

> there are a couple of expectation violations; for example the
> env-package is poked directly to own the offsets by the compiler.
> In the s-lang package I did that correctly, the environment keeps
> track of offsets and returns them, it doesn't just trust what it was
> given.

This pull-request moves ownership of indexes over to the environment package, where it belonges.  Since Lambdas cannot be nested they're very basic and we don't need to count offsets taking into account the parent too - just the current environment suffices.