### PR TITLE
Allow using the compiler directly.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -20,6 +20,10 @@ var tmplTxt string
 
 // Compiler holds our state
 type Compiler struct {
+
+	// source stores the program we're parsing.
+	source string
+
 	// text stores the text we emit as we compile various things.
 	text strings.Builder
 
@@ -35,13 +39,110 @@ type Compiler struct {
 }
 
 // New is our constructor
-func New() *Compiler {
-	return &Compiler{}
+func New(src string) *Compiler {
+
+	return &Compiler{source: src}
+}
+
+// Compile creates and returns the assembly language source for the given
+// list of functions.
+func (c *Compiler) Compile() (string, error) {
+
+	// Create a parser
+	p := parser.New(c.source)
+
+	// Parse the program into functions
+	defs, err := p.Parse()
+	if err != nil {
+		return "", fmt.Errorf("error parsing program %s", err)
+	}
+
+	// Ensure our string table is pristine
+	c.strings = make(map[string]string)
+
+	defuns := ""
+
+	// Generate the user-defined functions to our internal buffer.
+	for _, d := range defs {
+		err := c.emitCallable(d)
+		if err != nil {
+			return "", err
+		}
+		c.emitln("")
+	}
+
+	// Get them, and clear the buffer.
+	defuns = c.text.String()
+	c.text.Reset()
+
+	// Now user-defined lambdas
+	lambdas := ""
+	for _, l := range c.lambdas {
+		err := c.emitCallable(l)
+		if err != nil {
+			return "", err
+		}
+
+		c.emitln("")
+	}
+	lambdas = c.text.String()
+	c.text.Reset()
+
+	// Then the string-table for user-defined strings
+	stringTable := ""
+	c.emitln("section .data")
+	for id, str := range c.strings {
+		c.emitln("align 8")
+		c.emitln(id + ":")
+
+		// escape the "`" which are wrapped around the string.
+		str = strings.ReplaceAll(str, "`", "\\`")
+
+		c.emitln(fmt.Sprintf("     db `%s`, 0", str))
+	}
+	stringTable = c.text.String()
+	c.text.Reset()
+
+	// Define a simple structure we can pass to the text/template
+	// file we render for our output
+	type Generated struct {
+		// The defintions of defun's we've seen.
+		Defuns string
+
+		// Lambdas has all the lambda expressions we've seen.
+		Lambdas string
+
+		// StringTable contains the strings we've seen.
+		StringTable string
+	}
+
+	// Create an instance to populate the template with
+	x := &Generated{
+		Defuns:      defuns,
+		Lambdas:     lambdas,
+		StringTable: stringTable,
+	}
+
+	// Create a buffer to render the template to.
+	buf := bytes.Buffer{}
+
+	// Load the template, and parse it.
+	t1 := template.New("t1")
+	t1 = template.Must(t1.Parse(tmplTxt))
+
+	// Render the template.
+	err = t1.Execute(&buf, x)
+	if err != nil {
+		return "", err
+	}
+
+	// Now return the text of that rendered template.
+	return buf.String(), nil
 }
 
 // addString creates a unique label for our strings,
 // based on the SHA1-hash.  Interning them.
-func (g *Compiler) addString(str string) string {
+func (c *Compiler) addString(str string) string {
 	hasher := sha1.New()
 	hasher.Write([]byte(str))
 	sha := hex.EncodeToString(hasher.Sum(nil))
@@ -50,16 +151,16 @@ func (g *Compiler) addString(str string) string {
 }
 
 // label generates a new label, with the given prefix.
-func (g *Compiler) label(prefix string) string {
-	s := fmt.Sprintf("%s_%d", prefix, g.labelID)
-	g.labelID++
+func (c *Compiler) label(prefix string) string {
+	s := fmt.Sprintf("%s_%d", prefix, c.labelID)
+	c.labelID++
 	return s
 }
 
 // emitln writes a line of assembly/source into our internal buffer.
-func (g *Compiler) emitln(s string) {
-	g.text.WriteString(s)
-	g.text.WriteString("\n")
+func (c *Compiler) emitln(s string) {
+	c.text.WriteString(s)
+	c.text.WriteString("\n")
 }
 
 // asmName converts the given label into something nasm will accept.
@@ -67,7 +168,7 @@ func (g *Compiler) emitln(s string) {
 // It doesn't like special characters inside label names, and compiling
 // a function with a name like "not" or "abs" will cause errors when
 // they're called.  ("call abs" will result in a syntax error from nasm.)
-func (g *Compiler) asmName(name string) string {
+func (c *Compiler) asmName(name string) string {
 	switch name {
 
 	// comparisons
@@ -119,7 +220,7 @@ func (g *Compiler) asmName(name string) string {
 }
 
 // emitExpr emits the code for each of our expression AST types.
-func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
+func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 	switch n := e.(type) {
 
 	case *parser.Call:
@@ -135,15 +236,15 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 			}
 
 			for _, a := range n.Args {
-				err := g.emitExpr(a, ev)
+				err := c.emitExpr(a, ev)
 				if err != nil {
 					return err
 				}
-				g.emitln("    push rax")
+				c.emitln("    push rax")
 			}
 
 			for i := len(n.Args) - 1; i >= 0; i-- {
-				g.emitln(fmt.Sprintf(
+				c.emitln(fmt.Sprintf(
 					"    pop %s",
 					regs[i],
 				))
@@ -152,21 +253,21 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 			// lambda?
 			if offset, ok := ev.Lookup(symbol.Name); ok {
 
-				g.emitln(fmt.Sprintf(
+				c.emitln(fmt.Sprintf(
 					"    mov rax,[rbp-%d]",
 					offset,
 				))
 
 				// call lambda
-				g.emitln("UNTAG_REG rax")
-				g.emitln("mov r15, rax")
-				g.emitln("mov rax, [r15]")
-				g.emitln("call rax")
+				c.emitln("UNTAG_REG rax")
+				c.emitln("mov r15, rax")
+				c.emitln("mov rax, [r15]")
+				c.emitln("call rax")
 
 				return nil
 			} else {
 				// defun
-				g.emitln("    call " + g.asmName(symbol.Name))
+				c.emitln("    call " + c.asmName(symbol.Name))
 				return nil
 			}
 		}
@@ -181,127 +282,127 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		}
 
 		for _, a := range n.Args {
-			err := g.emitExpr(a, ev)
+			err := c.emitExpr(a, ev)
 			if err != nil {
 				return err
 			}
 
-			g.emitln("    push rax")
+			c.emitln("    push rax")
 		}
 
 		for i := len(n.Args) - 1; i >= 0; i-- {
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    pop %s",
 				regs[i],
 			))
 		}
 
 		// evaluate callable expression
-		err := g.emitExpr(n.Fn, ev)
+		err := c.emitExpr(n.Fn, ev)
 		if err != nil {
 			return err
 		}
 
 		// call lambda
-		g.emitln("UNTAG_REG rax")
-		g.emitln("mov r15, rax")
-		g.emitln("mov rax, [r15]")
-		g.emitln("call rax")
+		c.emitln("UNTAG_REG rax")
+		c.emitln("mov r15, rax")
+		c.emitln("mov rax, [r15]")
+		c.emitln("call rax")
 
 	case *parser.Cond:
 
-		label := g.label("case_")
+		label := c.label("case_")
 
 		// There are N test/bodies - compile the comparisons to jump to
 		// each body
-		for i, c := range n.Cases {
+		for i, cas := range n.Cases {
 
-			err := g.emitExpr(c.Case, ev)
+			err := c.emitExpr(cas.Case, ev)
 			if err != nil {
 				return err
 			}
 
-			g.emitln("    GET_TAG_BITS rax     ; get type bits")
-			g.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
-			g.emitln(fmt.Sprintf("     jnz %s_case_%d", label, i))
+			c.emitln("    GET_TAG_BITS rax     ; get type bits")
+			c.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
+			c.emitln(fmt.Sprintf("     jnz %s_case_%d", label, i))
 		}
 
 		// No match? Then fall-through to return nil
-		g.emitln(label + "_nil:")
-		g.emitln("   xor rax, rax")
-		g.emitln("   TAG_NIL_REG rax")
-		g.emitln(fmt.Sprintf("   jmp %s_end", label))
+		c.emitln(label + "_nil:")
+		c.emitln("   xor rax, rax")
+		c.emitln("   TAG_NIL_REG rax")
+		c.emitln(fmt.Sprintf("   jmp %s_end", label))
 
 		// now compile each body - making sure execution jumps to the end
-		for i, c := range n.Cases {
+		for i, cas := range n.Cases {
 
 			// case for each one
-			g.emitln(fmt.Sprintf("%s_case_%d:", label, i))
-			for _, expr := range c.Exprs {
-				err := g.emitExpr(expr, ev)
+			c.emitln(fmt.Sprintf("%s_case_%d:", label, i))
+			for _, expr := range cas.Exprs {
+				err := c.emitExpr(expr, ev)
 				if err != nil {
 					return err
 				}
 			}
-			g.emitln(fmt.Sprintf("   jmp %s_end", label))
+			c.emitln(fmt.Sprintf("   jmp %s_end", label))
 		}
 
 		// define end
-		g.emitln(label + "_end:")
+		c.emitln(label + "_end:")
 
 	case *parser.Char:
-		g.emitln(fmt.Sprintf("    mov rax, %d", n.Value))
-		g.emitln("   TAG_CHAR_REG rax")
+		c.emitln(fmt.Sprintf("    mov rax, %d", n.Value))
+		c.emitln("   TAG_CHAR_REG rax")
 
 	case *parser.Do:
 		for _, expr := range n.Exprs {
-			err := g.emitExpr(expr, ev)
+			err := c.emitExpr(expr, ev)
 			if err != nil {
 				return err
 			}
 		}
 
 	case *parser.Int:
-		g.emitln(fmt.Sprintf("    mov rax, %d", n.Value))
-		g.emitln("   TAG_INTEGER_REG rax")
+		c.emitln(fmt.Sprintf("    mov rax, %d", n.Value))
+		c.emitln("   TAG_INTEGER_REG rax")
 
 	case *parser.If:
-		elseLbl := g.label("else")
-		endLbl := g.label("endif")
+		elseLbl := c.label("else")
+		endLbl := c.label("endif")
 
-		err := g.emitExpr(n.Cond, ev)
+		err := c.emitExpr(n.Cond, ev)
 		if err != nil {
 			return err
 		}
 
-		g.emitln("    GET_TAG_BITS rax     ; get type bits")
-		g.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
-		g.emitln("    jz " + elseLbl)
+		c.emitln("    GET_TAG_BITS rax     ; get type bits")
+		c.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
+		c.emitln("    jz " + elseLbl)
 
-		err = g.emitExpr(n.Then, ev)
+		err = c.emitExpr(n.Then, ev)
 		if err != nil {
 			return err
 		}
 
-		g.emitln("    jmp " + endLbl)
+		c.emitln("    jmp " + endLbl)
 
-		g.emitln(elseLbl + ":")
+		c.emitln(elseLbl + ":")
 
 		// else branch is optional
 		if n.Else != nil {
-			err = g.emitExpr(n.Else, ev)
+			err = c.emitExpr(n.Else, ev)
 			if err != nil {
 				return err
 			}
 
 		}
-		g.emitln(endLbl + ":")
+		c.emitln(endLbl + ":")
 
 	case *parser.Lambda:
 
 		// create a unique name for this lambda
-		name := g.asmName(fmt.Sprintf("lambda_%d", g.labelID))
-		g.labelID++
+		name := c.asmName(fmt.Sprintf("lambda_%d", c.labelID))
+		c.labelID++
 
 		// We don't do analysis for captured variables,
 		// we just claim ALL of them.
@@ -314,15 +415,15 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		//   ...
 		size := 8 * (1 + len(n.Captures))
 
-		g.emitln("    mov rax, [heap_ptr]")
-		g.emitln(fmt.Sprintf(
+		c.emitln("    mov rax, [heap_ptr]")
+		c.emitln(fmt.Sprintf(
 			"    add qword [heap_ptr], %d",
 			size,
 		))
-		g.emitln("    mov rbx, rax")
+		c.emitln("    mov rbx, rax")
 
 		// store code pointer
-		g.emitln(fmt.Sprintf(
+		c.emitln(fmt.Sprintf(
 			"    mov qword [rbx], %s",
 			name,
 		))
@@ -335,25 +436,25 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 				panic("capture not found: " + cap)
 			}
 
-			g.emitln("; copy capture " + cap)
-			g.emitln(fmt.Sprintf(
+			c.emitln("; copy capture " + cap)
+			c.emitln(fmt.Sprintf(
 				"    mov rcx, [rbp-%d]",
 				offset,
 			))
 
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov [rbx+%d], rcx",
 				8*(i+1),
 			))
 		}
 
 		// return tagged closure
-		g.emitln("    mov rax, rbx")
-		g.emitln("    TAG_LAMBDA_REG rax")
+		c.emitln("    mov rax, rbx")
+		c.emitln("    TAG_LAMBDA_REG rax")
 
 		// save away the lambda in the list of lambdas
 		n.Name = name
-		g.lambdas = append(g.lambdas, n)
+		c.lambdas = append(c.lambdas, n)
 
 	case *parser.Let:
 		// create a new child environment
@@ -362,14 +463,14 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		// populate the new environment
 		for _, b := range n.Bindings {
 
-			err := g.emitExpr(b.Expr, ev)
+			err := c.emitExpr(b.Expr, ev)
 			if err != nil {
 				return err
 			}
 
 			offset := child.Define(b.Name)
 
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov [rbp-%d], rax",
 				offset,
 			))
@@ -377,7 +478,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 
 		// compile each expression within the body
 		for _, expr := range n.Body {
-			err := g.emitExpr(expr, child)
+			err := c.emitExpr(expr, child)
 			if err != nil {
 				return err
 			}
@@ -385,31 +486,31 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		}
 
 	case *parser.Nil:
-		g.emitln("    xor rax, rax     ; NIL")
-		g.emitln("    TAG_NIL_REG rax  ; Tagged")
+		c.emitln("    xor rax, rax     ; NIL")
+		c.emitln("    TAG_NIL_REG rax  ; Tagged")
 
 	case *parser.String:
 		// create a label, based on the hash of the content.
 		// This has the side-effect of interning.
-		lbl := g.addString(n.Value)
+		lbl := c.addString(n.Value)
 
 		// save the string, because we're gonna put it into the
 		// generated code, later.
-		g.strings[lbl] = n.Value
+		c.strings[lbl] = n.Value
 
 		// load the address of the label and tag.
-		g.emitln(fmt.Sprintf("    lea rax, %s", lbl))
-		g.emitln("    TAG_STRING_REG rax")
+		c.emitln(fmt.Sprintf("    lea rax, %s", lbl))
+		c.emitln("    TAG_STRING_REG rax")
 
 	case *parser.Set:
 
-		err := g.emitExpr(n.Expr, ev)
+		err := c.emitExpr(n.Expr, ev)
 		if err != nil {
 			return err
 		}
 
 		if offset, ok := ev.Lookup(n.Name); ok {
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov [rbp-%d], rax",
 				offset,
 			))
@@ -417,7 +518,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		}
 
 		if offset, ok := ev.LookupCapture(n.Name); ok {
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov [r15+%d], rax",
 				offset,
 			))
@@ -427,7 +528,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 
 	case *parser.Symbol:
 		if offset, ok := ev.Lookup(n.Name); ok {
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov rax, [rbp-%d]",
 				offset,
 			))
@@ -435,7 +536,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		}
 
 		if offset, ok := ev.LookupCapture(n.Name); ok {
-			g.emitln(fmt.Sprintf(
+			c.emitln(fmt.Sprintf(
 				"    mov rax, [r15+%d]",
 				offset,
 			))
@@ -456,7 +557,7 @@ func (g *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 //
 // The Lambda struct actually embeds a Defun one, with the extra capture fields being
 // the only difference.
-func (g *Compiler) emitCallable(obj any) error {
+func (c *Compiler) emitCallable(obj any) error {
 
 	// create new environment
 	ev := env.New(nil)
@@ -480,11 +581,11 @@ func (g *Compiler) emitCallable(obj any) error {
 	//
 	// Code that is common, and Defun-related
 	//
-	g.emitln(g.asmName(d.Name) + ":")
+	c.emitln(c.asmName(d.Name) + ":")
 
-	g.emitln("    push rbp")
-	g.emitln("    mov rbp, rsp")
-	g.emitln("    sub rsp, 256 ;; guess at space for locals")
+	c.emitln("    push rbp")
+	c.emitln("    mov rbp, rsp")
+	c.emitln("    sub rsp, 256 ;; guess at space for locals")
 
 	regs := []string{
 		"rdi",
@@ -499,7 +600,7 @@ func (g *Compiler) emitCallable(obj any) error {
 
 		offset := ev.Define(p)
 
-		g.emitln(fmt.Sprintf(
+		c.emitln(fmt.Sprintf(
 			"    mov [rbp-%d], %s",
 			offset,
 			regs[i],
@@ -523,101 +624,14 @@ func (g *Compiler) emitCallable(obj any) error {
 	//
 
 	for _, xpr := range d.Exprs {
-		err := g.emitExpr(xpr, ev)
+		err := c.emitExpr(xpr, ev)
 		if err != nil {
 			return err
 		}
 
 	}
 
-	g.emitln("    leave")
-	g.emitln("    ret")
+	c.emitln("    leave")
+	c.emitln("    ret")
 	return nil
-}
-
-// Compile creates and returns the assembly language source for the given
-// list of functions.
-func (g *Compiler) Compile(defs []*parser.Defun) (string, error) {
-
-	// Ensure our string table is pristine
-	g.strings = make(map[string]string)
-
-	defuns := ""
-
-	// Generate the user-defined functions to our internal buffer.
-	for _, d := range defs {
-		err := g.emitCallable(d)
-		if err != nil {
-			return "", err
-		}
-		g.emitln("")
-	}
-
-	// Get them, and clear the buffer.
-	defuns = g.text.String()
-	g.text.Reset()
-
-	// Now user-defined lambdas
-	lambdas := ""
-	for _, l := range g.lambdas {
-		err := g.emitCallable(l)
-		if err != nil {
-			return "", err
-		}
-
-		g.emitln("")
-	}
-	lambdas = g.text.String()
-	g.text.Reset()
-
-	// Then the string-table for user-defined strings
-	stringTable := ""
-	g.emitln("section .data")
-	for id, str := range g.strings {
-		g.emitln("align 8")
-		g.emitln(id + ":")
-
-		// escape the "`" which are wrapped around the string.
-		str = strings.ReplaceAll(str, "`", "\\`")
-
-		g.emitln(fmt.Sprintf("     db `%s`, 0", str))
-	}
-	stringTable = g.text.String()
-	g.text.Reset()
-
-	// Define a simple structure we can pass to the text/template
-	// file we render for our output
-	type Generated struct {
-		// The defintions of defun's we've seen.
-		Defuns string
-
-		// Lambdas has all the lambda expressions we've seen.
-		Lambdas string
-
-		// StringTable contains the strings we've seen.
-		StringTable string
-	}
-
-	// Create an instance to populate the template with
-	x := &Generated{
-		Defuns:      defuns,
-		Lambdas:     lambdas,
-		StringTable: stringTable,
-	}
-
-	// Create a buffer to render the template to.
-	buf := bytes.Buffer{}
-
-	// Load the template, and parse it.
-	t1 := template.New("t1")
-	t1 = template.Must(t1.Parse(tmplTxt))
-
-	// Render the template.
-	err := t1.Execute(&buf, x)
-	if err != nil {
-		return "", err
-	}
-
-	// Now return the text of that rendered template.
-	return buf.String(), nil
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -3,15 +3,11 @@ package compiler
 import (
 	"strings"
 	"testing"
-
-	"github.com/skx/slisp/parser"
 )
 
 func TestBasic(t *testing.T) {
 
-	c := New()
-
-	p := parser.New(`
+	c := New(`
 (defun foo (a b)
   "This is a demo"
   (* a b))
@@ -73,12 +69,7 @@ func TestBasic(t *testing.T) {
 )
 		`)
 
-	defs, err := p.Parse()
-	if err != nil {
-		t.Fatalf("error parsing %s", err)
-	}
-
-	out, err := c.Compile(defs)
+	out, err := c.Compile()
 	if err != nil {
 		t.Fatalf("failed to compile %s", err)
 	}
@@ -104,15 +95,9 @@ func TestErrors(t *testing.T) {
 	}
 
 	for _, tst := range tests {
-		c := New()
+		c := New(tst)
 
-		p := parser.New(tst)
-		defs, err := p.Parse()
-		if err != nil {
-			t.Fatalf("error parsing %s", err)
-		}
-
-		_, err = c.Compile(defs)
+		_, err := c.Compile()
 		if err == nil {
 			t.Fatalf("expected error, got none %s", tst)
 		}

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/skx/slisp/compiler"
-	"github.com/skx/slisp/parser"
 )
 
 //go:embed stdlib.slisp
@@ -18,21 +17,11 @@ var stdlibLisp string
 // compile is a helper to compile a program
 func compile(prg string) (string, error) {
 
-	// Create a parser
-	p := parser.New(prg)
-
-	// Parse into functions
-	defs, err := p.Parse()
-	if err != nil {
-		return "", fmt.Errorf("error parsing program %s", err)
-	}
-
 	// Create a compiler
-	c := compiler.New()
+	c := compiler.New(prg)
 
 	// Generate the code
-	txt := ""
-	txt, err = c.Compile(defs)
+	txt, err := c.Compile()
 	if err != nil {
 		return "", fmt.Errorf("error compiling program %s", err)
 	}


### PR DESCRIPTION
Consumers of the compiler object don't need to use the Parser directly, that's an internal matter.

This simplifies the `main.go` driver.

* Also renamed "g *Compiler" into "c *Compiler" to make more sense.
  * The old name was from when we were "g *Generator".

This closes #69.