### PR TITLE
Fix parsing to allow empty bodies.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -110,7 +110,7 @@ func (p *Parser) parseDefun() (*Defun, error) {
 	body := []Expr{}
 
 	// allow multiple expressions
-	for p.peek() != "" {
+	for p.peek() != "" && p.peek() != ")" {
 		// get the expression
 		expr, err := p.parseExpr()
 		if err != nil {
@@ -340,7 +340,7 @@ func (p *Parser) parseList() (Expr, error) {
 			body := []Expr{}
 
 			// allow multiple expressions
-			for p.peek() != "" {
+			for p.peek() != "" && p.peek() != ")" {
 				expr, err := p.parseExpr()
 				if err != nil {
 					return nil, err
@@ -405,7 +405,7 @@ func (p *Parser) parseList() (Expr, error) {
 			body := []Expr{}
 
 			// allow multiple expressions
-			for p.peek() != "" {
+			for p.peek() != "" && p.peek() != ")" {
 				expr, err := p.parseExpr()
 				if err != nil {
 					return nil, err

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -28,6 +28,26 @@ func TestParseValid(t *testing.T) {
 	}
 }
 
+func TestIssue68(t *testing.T) {
+
+	src := `
+(defun empty())
+
+(defun main ()
+  (let ((binding nil)))
+  (do)
+  (print (lambda ()))
+  (list)
+)
+`
+
+	p := New(src)
+	_, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected error parsing valid program; %v", err)
+	}
+}
+
 func TestBroken(t *testing.T) {
 
 	tests := []string{


### PR DESCRIPTION
This pull-request closes #68 by allowing empty defuns to be defined, even if there is little use for such a thing:

        (defun foo () )

Similar changes applied to:

* do
* let
* lambda

Test case added.