### PR TITLE
Make command-line arguments available to lisp

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -106,6 +106,15 @@ Here's another simple function:
        (* x x))
 
 
+There **must** be a function named `main`, as that is the entry-point to the lisp program.  This function can be defined either like so:
+
+    (defun main() ... )
+
+Or like this, if you wish to receive the command-line arguments, supplied as a list:
+
+    (defun main(args) ... )
+
+
 
 ## Lambdas
 
@@ -124,7 +133,7 @@ Here's an example of applying a function to each entry in a list:
 
 ## Lists
 
-Lists are internally created as cons-pairs, and you can create such a thing like so:
+Lists are internally created as cons-pairs, and you can create such a thing manually like so:
 
     ; Manually create the list "1 2 3"
     (cons 1 (cons 2 (cons 3 nil)))

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -10,16 +10,20 @@ Note that you might need to consult the source of the standard-library to see fu
 
 The only notable special symbol is `nil` - the nil value.
 
-Characters are specified via the `#\X` syntax, for escaped characters you just need to add the escape:
-
-* `#\a` -> "a"
-* `#\b` -> "b"
-* ..
-* `#\X` -> "X"
-* `#\\n` -> newline
-* `#\\t` -> tab
-
-Finally strings are enclosed in "quotes like this", and integers are converted to numbers.
+* Comments are begun with ";" and continue until the end of the line.
+  * There are no block comments.
+* We only support integers, but they may be written in any base the golang `strconv.ParseInt` function supports:
+  * `(print 3)`
+  * `(print 0xff)`
+  * `(print 0b10101010)`
+* Floating point numbers are not supported, so this is an error:
+  * `(print 3.4)`
+* Strings are just encoded literally, and escaped characters are honored:
+  * `(print "Hello, world\n")`
+* Characters are written with a `#\` prefix:
+  * `(print #\*)`
+* Lists are written using parenthesis to group them:
+  * `(print (list 1 2 3))`
 
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quick links:
       (if (<= n 1) 1 (* n (fact (- n 1)))))
 
     ;; entry-point
-    (defun main ()
+    (defun main (args)
       (println "Showing some factorials:")
       (println (fact 4))
       (println (fact 5))

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It should be noted that we prepend a standard library of functions to all user p
 * A rough and ready bump-allocator used for heap-allocated cons-cells.
 * Mathematical operations:
   * `+`, `-`, `*`, `/`, and `%`.
-* Comparision operations:
+* Comparison operations:
   * `=`, `<`, `<=`, `>=`, `>`, and `!` to invert a result.
 * Special forms
   * `(cond ..)`

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,4 +1,4 @@
-// package compiler is our main workhorse, which creates an assembly
+// Package compiler is our main workhorse, which creates an assembly
 // language version of the given input program and outputs it to STDOUT.
 package compiler
 
@@ -58,13 +58,13 @@ func (c *Compiler) Compile() (string, error) {
 	}
 
 	// Ensure our string table is pristine
-	c.strings = make(map[string]string)
+	c.strings = map[string]string{}
 
 	defuns := ""
 
 	// Generate the user-defined functions to our internal buffer.
 	for _, d := range defs {
-		err := c.emitCallable(d)
+		err = c.emitCallable(d)
 		if err != nil {
 			return "", err
 		}
@@ -78,7 +78,7 @@ func (c *Compiler) Compile() (string, error) {
 	// Now user-defined lambdas
 	lambdas := ""
 	for _, l := range c.lambdas {
-		err := c.emitCallable(l)
+		err = c.emitCallable(l)
 		if err != nil {
 			return "", err
 		}
@@ -544,7 +544,7 @@ func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 		}
 		return fmt.Errorf("unknown variable: %s", n.Name)
 	default:
-		return fmt.Errorf("emitExpr: Unhandled node type:%T value:%V\n", n, n)
+		return fmt.Errorf("emitExpr: Unhandled node type:%T value:%V", n, n)
 	}
 	return nil
 }

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -93,11 +93,31 @@ global _start
 section .text
 
 _start:
+
+_start:
     mov rax, heap        ; setup our heap pointer
     mov [heap_ptr], rax  ; cons cells are heap-allocated
 
+    mov rcx, [rsp]       ; argc
+    lea rbx, [rsp+8]     ; rbx -> argv[0]
+    xor rsi, rsi         ; Start with NIL
+    TAG_NIL_REG rsi
+
+.loop:
+    test rcx, rcx
+    jz .done
+    dec rcx
+    mov rdi, [rbx + rcx*8]  ; argv[rcx]
+    TAG_STRING_REG rdi      ; Tag as Lisp string
+    call fn_cons            ; cons(string, list)
+    mov rsi, rax            ; result becomes next list
+    jmp .loop
+
+.done:
+    mov rdi, rsi            ; first SysV argument
+
     call fn_main
-    mov rdi, rax         ; exit code is the last expression
+    mov rdi, rax            ; exit code is the last expression
     UNTAG_REG rdi
     mov rax, 60
     syscall

--- a/example.lisp
+++ b/example.lisp
@@ -44,7 +44,7 @@
 ;;
 ;; main is the entry-point to our compiled code.
 ;;
-(defun main ()
+(defun main (args)
   "main is the (mandatory) entry-point to our code.
 
 This must always be defined, and is where execution starts from."
@@ -59,7 +59,8 @@ This must always be defined, and is where execution starts from."
         (x (double 13))
         (y 12))
 
-     (println "Hello World! I am a compiled lisp")
+    (println "Hello World! I am a compiled lisp, and I received command line arguments:")
+    (println args)
 
      (if nil
          (do

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,5 +1,5 @@
-// Package parser contains our AST definitions, which are turned into
-// code by our compiler.
+// Package parser contains our AST definitions, and the code necessary
+// to populate them from our input.
 //
 // Most of this package is very minimal stuff, as lisp is very low on
 // syntax.
@@ -73,10 +73,7 @@ func (p *Parser) next() string {
 // expectNext confirms the next token is what is specified, if it isn't this
 // will panic.
 func (p *Parser) expectNext(s string) bool {
-	if p.next() != s {
-		return false
-	}
-	return true
+	return p.next() == s
 }
 
 // parseDefun parses a single function definition, containing an arbitrary number
@@ -453,7 +450,7 @@ func (p *Parser) parseList() (Expr, error) {
 			}
 
 			if !p.expectNext(")") {
-				return nil, fmt.Errorf("expected ')' to close set!")
+				return nil, fmt.Errorf("expected ')' to close set! expression")
 			}
 
 			return &Set{


### PR DESCRIPTION
This is a simple change which just needed building a Lisp-List of the arguments which are already passed to our startup code.

Now that list is the first argument, so if `defun main ..` was defined to accept an argument it will just work.

This closes #73.