### PR TITLE
Implement `getc` and use it in our brainfuck interpreter

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -74,6 +74,8 @@ Core primitives are implemented in assembly language, and can be found within th
     * Terminate execution.
   * `explode`
     * Convert the supplied string to a list of characters.
+  * `getc`
+    * Read a single character from STDIN, return NIL on failure.
   * `implode`
     * Convert the given list of characters to a string.
   * `newline`

--- a/brainfuck.lisp
+++ b/brainfuck.lisp
@@ -4,8 +4,6 @@
 ;; This is terrible.
 ;; This works.
 ;;
-;; TODO: Wrap cell inc/dec - via % 256.
-;; TODO: Input via ","; note our stdlib is missing getc..
 
 ;;; Helpers
 
@@ -53,14 +51,14 @@
 (defun execPlus (program i cells ptr)
   (run program
        (+ i 1)
-       (setNth cells ptr (+ (nth cells ptr) 1))
+       (setNth cells ptr (% (+ (nth cells ptr) 1) 256))
        ptr))
 
 ;; - handler
 (defun execMinus (program i cells ptr)
   (run program
        (+ i 1)
-       (setNth cells ptr (- (nth cells ptr) 1))
+       (setNth cells ptr (% (- (nth cells ptr) 1) 256))
        ptr))
 
 ;; > handler
@@ -75,6 +73,13 @@
 (defun execDot (program i cells ptr)
     (putc (chr (nth cells ptr)))
     (run program (+ i 1) cells ptr))
+
+;; , handler
+(defun execComma (program i cells ptr)
+  (let ((x (getc)))
+    (if (nil? x)
+         (set! x 0))
+    (run program (+ i 1) (setNth cells ptr x) ptr)))
 
 ;; [ handler
 (defun execOpen (program i cells ptr)
@@ -119,6 +124,7 @@
           ((= ins #\>)  (execGt    program i cells ptr))
           ((= ins #\<)  (execLt    program i cells ptr))
           ((= ins #\.)  (execDot   program i cells ptr))
+          ((= ins #\,)  (execComma program i cells ptr))
           ((= ins #\[)  (execOpen  program i cells ptr))
           ((= ins #\])  (execClose program i cells ptr))
 
@@ -128,7 +134,7 @@
 
 ;; driver
 (defun brainfuck (program)
-  "Run the given program with 30 cells"
+  "Run the given program with a small number of cells"
   (run
    ;; program
    (explode program)
@@ -137,13 +143,32 @@
    ;; cells
    (list 0 0 0 0 0 0 0 0 0 0   ; 10
          0 0 0 0 0 0 0 0 0 0   ; 20
-         0 0 0 0 0 0 0 0 0 0 ) ; 30
+         0 0 0 0 0 0 0 0 0 0   ; 30
+         0 0 0 0 0 0 0 0 0 0   ; 40
+         0 0 0 0 0 0 0 0 0 0   ; 50
+         0 0 0 0 0 0 0 0 0 0   ; 60
+         0 0 0 0 0 0 0 0 0 0   ; 70
+         0 0 0 0 0 0 0 0 0 0   ; 80
+         0 0 0 0 0 0 0 0 0 0   ; 90
+         0 0 0 0 0 0 0 0 0 0   ;100
+         )
    ;; cell ptr value
    0))
 
 
 ;; Entry-point
-(defun main ()
+(defun main (args)
 
+  ; If we got an argument
+  (if (= (length args) 2)
+      ; and the argument was "cat"
+      (if (= (car (cdr args)) "cat")
+          ; run the cat-program
+          (do
+           (brainfuck ",[.,]")
+           (exit 0))))
+
+  ; not two arguments, or not cat
+  ; hello world
   (brainfuck "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.")
-)
+  )

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -460,6 +460,29 @@ fn_putc:
     syscall
     ret
 
+section .text.getc,"ax",@progbits
+
+;; Read an ASCII character from STDIN, return NIL on failure.
+fn_getc:
+     mov     rax, 0        ; SYS_read
+     mov     rdi, 0        ; STDIN_FILENO
+     mov rsi, putc_buffer
+     mov     rdx, 1        ; read 1 byte
+     syscall
+
+     cmp rax, 1
+     jne .getc_failed
+
+     xor rax,rax
+     mov al, byte [putc_buffer]
+     TAG_INTEGER_REG rax
+     ret
+.getc_failed:
+     xor rax, rax
+     TAG_NIL_REG rax
+     ret
+
+
 section .text.print_str,"ax",@progbits
 
 ;; Print the given string.
@@ -757,7 +780,7 @@ section .bss
 ;; heap storage
 align 16
 heap:
-    resb 1048576
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
 
 ;; offset used of our heap area.
 heap_ptr:


### PR DESCRIPTION
This pull-request closes #74 by implementing `(getc)`.

`getc` returns a single character read from STDIN, or nil on failure.  This is now hooked up to our brainfuck interpreter and  I extended that to run two programs:

* `./brainfuck` - Runs the "Hello World" program.
* `./brainfuck cat` - Runs the "cat" program.

Testing:

```sh
$ make clean all
$ cat go.mod | ./brainfuck cat
module github.com/skx/slisp

go 1.26.1
```

**NOTE** The brainfuck interpreter will segfault when running `factor.bf` not sure why - used all the heap?  stack limit?  To be debugged separately.