### PR TITLE
Add `t` as a true symbol

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -10,12 +10,13 @@ Primitive types work as you would expect:
 
 * Comments are begun with ";" and continue until the end of the line.
   * There are no block comments.
-* We only support integers, but they may be written in any base the golang `strconv.ParseInt` function supports:
+* We only support integer numbers, but they may be written in any base the golang `strconv.ParseInt` function supports:
   * `(print 3)`
   * `(print 0xff)`
   * `(print 0b10101010)`
 * Floating point numbers are not supported, so this is an error:
   * `(print 3.4)`
+* We don't have a boolean type, but `nil` (or the empty list) is false, and `t` is true.
 * Strings are just encoded literally, and escaped characters are honored:
   * `(print "Hello, world\n")`
 * Characters are written with a `#\` prefix:

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -126,6 +126,8 @@ The implementation of these primitives can be found in the file [stdlib.slisp](s
 
 * `abs`
   * Return the absolute value of the given integer.  (e.g. 3 -> 3, and -3 -> 3).
+* `and`
+  * Test if every item in a list is true.
 * `append`
   * Append the given value to the specified list.  If the list is empty just return the specified item.
 * `even?`
@@ -161,6 +163,8 @@ The implementation of these primitives can be found in the file [stdlib.slisp](s
   * Return 1 if the given number is odd, nil otherwise.
 * `one?`
   * Return true if the number is one.
+* `or`
+  * Is any value in the given list non-nil?
 * `pos?`
   * Return true if the number is positive.
 * `print`

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -8,11 +8,11 @@ Note that you might need to consult the source of the standard-library to see fu
 
 ## Symbols / Types
 
-The only notable special symbol is `nil` - the nil value.
+The only notable special symbols are `nil`, which is synonymous with false and the empty list, and `t` which is a true value.
 
 * Comments are begun with ";" and continue until the end of the line.
   * There are no block comments.
-* We only support integers, but they may be written in any base the golang `strconv.ParseInt` function supports:
+* We only support integer numbers, but they may be written in any base the golang `strconv.ParseInt` function supports:
   * `(print 3)`
   * `(print 0xff)`
   * `(print 0b10101010)`

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -208,6 +208,11 @@ func (p *Parser) parseExpr() (Expr, error) {
 		return &Nil{}, nil
 	}
 
+	// true?
+	if t == "t" {
+		return &Int{Value: 1}, nil
+	}
+
 	// symbol
 	return &Symbol{Name: t}, nil
 }

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -51,6 +51,24 @@
   (newline))
 
 
+;;; logical functions
+
+
+(defun and (xs)
+  "Return true if every item in the specified list is true.
+
+NOTE: This is not a macro, so all arguments are evaluated."
+  (let ((res (filter xs (lambda (x) x))))
+    (= (length xs) (length res))))
+
+
+(defun or (xs)
+  "Return true if any value in the specified list contains a true value.
+
+NOTE: This is not a macro, so all arguments are evaluated."
+  (let ((res (filter xs (lambda (x) x))))
+    (> (length res) 0)))
+
 ;;; Maths functions
 
 (defun abs (n)
@@ -221,9 +239,7 @@ Incrementing by the given step each time."
   "Create a new list by calling the given function for every list element."
   (if (nil? xs)
       nil
-      (cons
-       (fn (car xs))
-       (map fn (cdr xs)))))
+      (cons (fn (car xs)) (map fn (cdr xs)))))
 
 (defun member? (xs item)
   "Return true if the specified item is found within the given list."
@@ -248,6 +264,12 @@ Incrementing by the given step each time."
   "Reverse the contents of the specified list."
   (reverse-inner xs nil))
 
+
+;;; system functions
+
+(defun getenv (name)
+  (getenv-loop name (environment)))
+
 (defun getenv-loop (name xs)
   (if xs
       (let ((parts (split (car xs) #\=)))
@@ -257,6 +279,3 @@ Incrementing by the given step each time."
                 (getenv-loop name (cdr xs)))
             (getenv-loop name (cdr xs))))
       nil))
-
-(defun getenv (name)
-  (getenv-loop name (environment)))

--- a/test/logical.lisp
+++ b/test/logical.lisp
@@ -1,0 +1,23 @@
+(defun main ()
+  
+  (println "start")
+
+  ; and; true
+  (if (and (list t t))
+      (println "and is OK"))
+  ; and; false
+  (if (and (list t t t t nil t))
+     (println "not ok")
+     (println "Still okay!"))
+
+  ; or: true
+  (if (or (list t nil nil nil ))
+      (println "or is OK"))
+  ; or: false
+  (if (or (list nil nil nil ))
+      (println "not OK")
+      (println "OR is still okay :)"))
+
+
+  (println "end")
+  )

--- a/test/logical.test.expected
+++ b/test/logical.test.expected
@@ -1,0 +1,6 @@
+start
+and is OK
+Still okay!
+or is OK
+OR is still okay :)
+end


### PR DESCRIPTION
Define a value `t` which is used for "true".  We don't have a false symbol, but `nil` is used for that - which is the same as the empty list.

Added also documentation and two new stdlib functions; `and` & `or`, along with test-programs for them both.

This closes #89 