### PR TITLE
Implement the special form `while`

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1,6 +1,7 @@
 # Brief `slisp` Introduction
 
-`slisp` is a typical toy lisp with support for integers, strings, characters, lambdas, and functions.
+`slisp` is a typical toy lisp with support for floating-point numbers,
+integers, strings, characters, lambdas, and functions.
 
 
 
@@ -152,6 +153,19 @@ But using the `list` function allows that to be done more neatly:
     (list 1 2 3)
 
 (For the common case of creating lists of numbers see the `nat`, `seq` and `range` functions in our [PRIMITIVES.md](PRIMITIVES.md) list.)
+
+
+
+## Looping
+
+We support the `while` expression to run loops:
+
+    (let ((i 0))
+      (while (< i 10)
+        (println i)
+        (set! i (+ i 1))))
+
+You can see this demonstrated in the [brainfuck.lisp](brainfuck.lisp) program.
 
 
 

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -49,7 +49,8 @@ Special forms are things that are built into the compiler core, and handled spec
   * Create a list.
 * `set!`
   * Set the value of a variable.
-
+* `while`
+  * Run the given body for as long as the specified condition is non-nil.
 
 
 ## Core Primitives

--- a/brainfuck.lisp
+++ b/brainfuck.lisp
@@ -63,95 +63,69 @@
             (findClose len program (+ pos 1) depth)))))
 
 
-;;; Brainfuck Handlers
-
-;; + handler
-(defun execPlus (len program i cells ptr)
-  (run len
-       program
-       (+ i 1)
-       (setNth cells ptr (% (+ (nth cells ptr) 1) 256))
-       ptr))
-
-;; - handler
-(defun execMinus (len program i cells ptr)
-  (run len
-       program
-       (+ i 1)
-       (setNth cells ptr (% (- (nth cells ptr) 1) 256))
-       ptr))
-
-;; > handler
-(defun execGt (len program i cells ptr)
-  (run len program (+ i 1) cells (+ ptr 1)))
-
-;; < handler
-(defun execLt (len program i cells ptr)
-  (run len program (+ i 1) cells (- ptr 1)))
-
-;; . handler
-(defun execDot (len program i cells ptr)
-    (putc (chr (nth cells ptr)))
-    (run len program (+ i 1) cells ptr))
-
-;; , handler
-(defun execComma (len program i cells ptr)
-  (let ((x (getc)))
-    (if (nil? x)
-         (set! x 0))
-    (run len program (+ i 1) (setNth cells ptr x) ptr)))
-
-;; [ handler
-(defun execOpen (len program i cells ptr)
-  (if (= (nth cells ptr) 0)
-      (run len program
-           (+ (findClose len program (+ i 1) 1) 1)
-           cells
-           ptr)
-      (run len program
-           (+ i 1)
-           cells
-           ptr)))
-
-;; ] handler
-(defun execClose (len program i cells ptr)
-  (if (= (nth cells ptr) 0)
-      (run len
-           program
-           (+ i 1)
-           cells
-           ptr)
-      (run len
-           program
-           (+ (findOpen len program (- i 1) 1) 1)
-           cells
-           ptr)))
-
 
 ;;; Interpreter
 
-;; Run a brainfuck program
-(defun run (len program i cells ptr)
+(defun run (program)
+  (let ((i 0)
+        (len (length program))
+        (ptr 0)
+        (cells (makeCells 1000)))
 
-  ; if we're inside the program
-  (if (< i len)
-
-      ;; get the instruction
+    (while (< i len)
       (let ((ins (nth program i)))
-
-        ;; dispatch it
         (cond
-          ((= ins #\+)  (execPlus  len program i cells ptr))
-          ((= ins #\-)  (execMinus len program i cells ptr))
-          ((= ins #\>)  (execGt    len program i cells ptr))
-          ((= ins #\<)  (execLt    len program i cells ptr))
-          ((= ins #\.)  (execDot   len program i cells ptr))
-          ((= ins #\,)  (execComma len program i cells ptr))
-          ((= ins #\[)  (execOpen  len program i cells ptr))
-          ((= ins #\])  (execClose len program i cells ptr))
 
-          ;; ignore unknown character/instruction
-          (1 (run len program (+ i 1) cells ptr))))))
+          ;; +
+          ((= ins #\+) (do
+                        (set! cells
+                              (setNth cells ptr
+                                      (% (+ (nth cells ptr) 1) 256)))
+                        (set! i (+ i 1))))
+
+          ;; -
+          ((= ins #\-) (do
+                        (set! cells
+                              (setNth cells ptr
+                                      (% (- (nth cells ptr) 1) 256)))
+                        (set! i (+ i 1))))
+
+          ;; >
+          ((= ins #\>) (do
+                        (set! ptr (+ ptr 1))
+                        (set! i (+ i 1))))
+
+          ;; <
+          ((= ins #\<) (do
+                        (set! ptr (- ptr 1))
+                        (set! i (+ i 1))))
+
+          ;; [
+          ((= ins #\[)
+           (if (= (nth cells ptr) 0)
+               (set! i (+ (findClose len program (+ i 1) 1) 1))
+               (set! i (+ i 1))))
+
+          ;; ]
+          ((= ins #\])
+           (if (= (nth cells ptr) 0)
+               (set! i (+ i 1))
+               (set! i (+ (findOpen len program (- i 1) 1) 1))))
+
+          ;; ,
+          ((= ins #\.) (do
+                        (putc (chr (nth cells ptr)))
+                        (set! i (+ i 1))))
+
+          ;; ,
+          ((= ins #\,) (do
+                        (set! cells
+                              (setNth cells ptr
+                                      (% (getc) 256)))
+                        (set! i (+ i 1))))
+
+          ;; skip over unknown instructions
+          (t (set! i (+ i 1))))))))
 
 
 ;; Create ranges of numbers in a list
@@ -159,11 +133,6 @@
     (if (> count 0)
         (cons 0 (makeCells (- count 1)))
       nil))
-
-;; driver
-(defun brainfuck (program)
-  "Run the given program with 1000 cells."
-  (run (length program) (explode program) 0 (makeCells 1000) 0))
 
 
 ;; Entry-point
@@ -184,4 +153,4 @@
                 (println (car (cdr args)))
                  (exit 1))))))
 
-  (brainfuck program)))
+  (run (explode program))))

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -606,6 +606,44 @@ func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 			return nil
 		}
 		return fmt.Errorf("unknown variable: %s", n.Name)
+
+	case *parser.While:
+
+		// create label for now, and the end
+		whileStart := c.label("while_start")
+		whileEnd := c.label("while_end")
+
+		// We're at the start, where we loop again
+		// to test the condition each time
+		c.emitln(whileStart + ":")
+
+		// compile the condition
+		err := c.emitExpr(n.Cond, ev)
+		if err != nil {
+			return err
+		}
+
+		// If the condition is "nil" we jump
+		// to the end.  Otherwise fall through
+		// to run the body..
+		c.emitln("    GET_TAG_BITS rax     ; get type bits")
+		c.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
+		c.emitln("    jz " + whileEnd)
+
+		// assemble the body
+		for _, expr := range n.Exprs {
+			err := c.emitExpr(expr, ev)
+			if err != nil {
+				return err
+			}
+		}
+
+		// loop around again
+		c.emitln("    jmp " + whileStart)
+
+		// but mark where the body is over.
+		c.emitln(whileEnd + ":")
+
 	default:
 		return fmt.Errorf("emitExpr: Unhandled node type:%T value:%V", n, n)
 	}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -89,6 +89,13 @@ func FuzzProject(f *testing.F) {
 		     (= n 1) (print "one")
 		     (= n 2) (print "two")
 		     ))))`,
+
+		// while
+		`(defun main() (while nil (print "ok")))`,
+		`(defun main() (let ((i 0))
+				 (while (< i 10)
+				   (println i)
+				   (set! i (+ i 1)))))`,
 	}
 
 	//

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -13,7 +13,7 @@ type Char struct {
 }
 
 type Float struct {
-	Value float64
+       Value float64
 }
 
 type Int struct {
@@ -88,3 +88,9 @@ type Set struct {
 	Name string
 	Expr Expr
 }
+
+type While struct {
+	Cond  Expr
+	Exprs []Expr
+}
+

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -473,6 +473,30 @@ func (p *Parser) parseList() (Expr, error) {
 				Name: name,
 				Expr: expr,
 			}, nil
+
+		case "while":
+			cond, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+
+			var exprs []Expr
+
+			for p.peek() != ")" && p.peek() != "" {
+				x, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				exprs = append(exprs, x)
+			}
+
+			if !p.expectNext(")") {
+				return nil, fmt.Errorf("expected ')' after while-expressions")
+			}
+
+			return &While{Cond: cond,
+				Exprs: exprs,
+			}, nil
 		}
 	}
 


### PR DESCRIPTION
This allows some natural things, and allowed me to rewrite the `brainfuck.lisp` interpreter as a non-recursive implementation.

Damn thing still takes minutes to print the _first line_. of the mandlebrot example, but it no longer segfaults due to stack exhaustion so that's a little win of its own

This close #96.