### PR TITLE
Record function names as we execute them.

### DIFF
--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -59,7 +59,6 @@
     or %1, TAG_ID_LAMBDA
 %endmacro
 
-
 ; tag a register as a character
 %macro TAG_CHAR_REG 1
     sal %1, 3
@@ -98,6 +97,28 @@ TAG_ID_CHAR    equ 0b100
 TAG_ID_FLOAT   equ 0b101
 TAG_ID_UNUSED  equ 0b110  ; boolean?
 TAG_ID_NIL     equ 0b111
+
+
+;;
+;; Declare a function which will record itself as having
+;; been started.  We use this in our type-error handler to
+;; allow easy debugging.  LOL.
+;;
+%macro FUNC 1
+    %defstr __fname %1    ; Define a string
+
+    section .rodata       ; Place the string in the RODATA section
+%%name:
+    db __fname, 0
+
+    section .text.%1,"ax",@progbits  ; Go back to text
+    global %1                        ; The function is global
+%1:                                  ; Declare the function
+    lea rax, [rel %%name]            ; Get the string ptr
+    mov [rel last_function], rax     ; save the address in $last_function
+%endmacro
+
+
 
 
 ;;; 2. User-defined functions (defuns)
@@ -266,7 +287,7 @@ nilp:
 section .text.plus,"ax",@progbits
 
 ;; +
-plus:
+FUNC plus
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
@@ -337,7 +358,7 @@ plus_integer:
 section .text.minus,"ax",@progbits
 
 ;; -
-minus:
+FUNC minus
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
@@ -409,7 +430,7 @@ integer_minus:
 section .text.divide,"ax",@progbits
 
 ;; /
-divide:
+FUNC divide
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
@@ -470,7 +491,6 @@ divide:
     TAG_FLOAT_REG rax       ; type
     ret                     ; return
 
-
 integer_divide:
    UNTAG_REG rdi
    UNTAG_REG rsi
@@ -485,13 +505,12 @@ integer_divide:
 section .text.modulus,"ax",@progbits
 
 ;; %
-modulus:
+FUNC modulus
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
    GET_TAG_BITS rax     ; type of arg
    add rax, rbx
-;   cmp rax, 0           ; both integerss?
    jz modulus_integer
    jmp type_error       ; type error
 modulus_integer:
@@ -509,14 +528,13 @@ modulus_integer:
 section .text.multiply,"ax",@progbits
 
 ;; *
-multiply:
+FUNC multiply
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
    GET_TAG_BITS rax     ; type of arg
    add rax, rbx         ; zero result? then both ints
    jz integer_multiply
-
 
    ; Okay the values are either:
    ;  float + float
@@ -586,7 +604,7 @@ section .text.not,"ax",@progbits
 ;; NOT
 ;; a nil becomes 1.
 ;; anything else becomes nil
-fn_not:
+FUNC fn_not
     mov rax, rdi
     GET_TAG_BITS rax
     cmp rax, TAG_ID_NIL
@@ -602,7 +620,7 @@ fn_not:
 section .text.equals,"ax",@progbits
 
 ;; =
-equals:
+FUNC equals
     mov rax, rdi
     mov rbx, rsi
     GET_TAG_BITS rbx     ; type of arg
@@ -640,7 +658,7 @@ section .text.lte,"ax",@progbits
 ;;
 ;; Note: The result of this function is inverted for ">".
 ;;
-lt_equals:
+FUNC lt_equals
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
@@ -715,7 +733,7 @@ lte_integer:
 section .text.gte,"ax",@progbits
 
 ;; >=
-gt_equals:
+FUNC gt_equals
    mov rax, rdi
    mov rbx, rsi
    GET_TAG_BITS rbx     ; type of arg
@@ -791,7 +809,7 @@ section .text.lt,"ax",@progbits
 
 
 ;; < - this is the inverse of >=
-lt:
+FUNC lt
     call gt_equals
     mov rdi, rax
     call fn_not
@@ -801,7 +819,7 @@ lt:
 section .text.gt,"ax",@progbits
 
 ;; > - this is the inverse of <=
-gt:
+FUNC gt
     call lt_equals
     mov rdi, rax
     call fn_not
@@ -927,6 +945,7 @@ fn_printint:
     push rbp
     mov rbp, rsp
     sub rsp, 64
+    mov rax, rdi
     UNTAG_REG rax
 
     mov r8, 0            ; remember sign
@@ -968,7 +987,7 @@ fn_printint:
 section .text.exit,"ax",@progbits
 
 ;; terminate execution with the given exit-code
-fn_exit:
+FUNC fn_exit
     UNTAG_REG rdi
     mov rax, 60     ; sys_exit
     syscall
@@ -988,7 +1007,7 @@ fn_newline:
 section .text.putc,"ax",@progbits
 
 ;; Write the given ASCII character to STDOUT
-fn_putc:
+FUNC fn_putc
     mov rax, rdi
     UNTAG_REG rax
     mov [putc_buffer],  al  ; store character
@@ -1002,7 +1021,7 @@ fn_putc:
 section .text.getc,"ax",@progbits
 
 ;; Read an ASCII character from STDIN, return NIL on failure.
-fn_getc:
+FUNC fn_getc
      mov     rax, 0        ; SYS_read
      mov     rdi, 0        ; STDIN
      mov rsi, putc_buffer
@@ -1050,7 +1069,7 @@ fn_printstr:
 section .text.chr,"ax",@progbits
 
 ;; chr - convert an integer to a character
-fn_chr:
+FUNC fn_chr
     mov rbx, rdi
     GET_TAG_BITS rbx
     cmp rbx, TAG_ID_INTEGER
@@ -1065,7 +1084,7 @@ fn_chr:
 section .text.ord,"ax",@progbits
 
 ;; ord - convert a character to an integer.
-fn_ord:
+FUNC fn_ord
     mov rbx, rdi
     GET_TAG_BITS rbx
     cmp rbx, TAG_ID_CHAR
@@ -1080,7 +1099,7 @@ section .text.cons,"ax",@progbits
 ;; Allocate space for a new cons cell, return it in RAX.
 ;;
 ;; 16-bytes; first has the CAR, second the CDR.
-fn_cons:
+FUNC fn_cons
     mov rax, [heap_ptr]      ; get the value of the heap pointer
     add qword [heap_ptr], 16 ; bump it by 2x ptrs
     mov [rax], rdi           ; store first item
@@ -1091,7 +1110,7 @@ fn_cons:
 section .text.car,"ax",@progbits
 
 ;; Get the first item in the cons cell.
-fn_car:
+FUNC fn_car
     mov rbx, rdi
     GET_TAG_BITS rbx
     cmp rbx, TAG_ID_CONS
@@ -1103,7 +1122,7 @@ fn_car:
 section .text.cdr,"ax",@progbits
 
 ;; Get the second item in the cons cell.
-fn_cdr:
+FUNC fn_cdr
     mov rbx, rdi
     GET_TAG_BITS rbx
     cmp rbx, TAG_ID_CONS
@@ -1118,13 +1137,17 @@ type_error:
     mov rdi, type_error_msg
     TAG_STRING_REG rdi
     call fn_printstr
+    mov rdi, qword [rel last_function]
+    TAG_STRING_REG rdi
+    call fn_printstr
+    call fn_newline
     mov rdi, 1              ; exit-code
     jmp fn_exit
 
 section .data
 align 8
 type_error_msg:
-        db `Type error.  Aborting.\n`
+        db `Type error! Aborted inside `
         db 00
 
 section .text.explode,"ax",@progbits
@@ -1803,6 +1826,10 @@ section .bss
 align 16
 heap:
     resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+
+;; last function we've called
+last_function:
+    resq 1
 
 ;; offset used of our heap area.
 heap_ptr:


### PR DESCRIPTION
We have some type-checking which will call (exit) if things fail to meet expectations.  To ease debugging output the name of the function that does that.

This closes #98.

Instead of just defining functions "foo" like so:

.section text ..
foo:

We now use a macro which auto-creates a string and saves the address of that string in the $last_address variable so we can print it in our failure routine.