### PR TITLE
`nth` and `setnth` are assembly-primitives

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -125,6 +125,9 @@ Note that functions have their names mangled a little bit ("-" is converted to "
     * Print the given string.
   * `random`
     * Return a random integer between zero and N.
+  * `setnth`
+    * Update the Nth item in the given list with the specified value.
+    * The list is updated in-place.
   * `split`
     * Split a string by the given character, and return a list of "(before after)".  Return nil if the character isn't found.
   * `strcat`

--- a/brainfuck.lisp
+++ b/brainfuck.lisp
@@ -10,48 +10,58 @@
 ;; (which is the "hello world" program).
 ;;
 
-;;; Helpers
-
-;; Return a copy of the given list, with the Nth item set to the given value.
-(defun setNth (list n val)
-  (if (> n 0)
-      (cons (car list)
-            (setNth (cdr list) (- n 1) val))
-      (cons val (cdr list))))
-
 
 ;;; Brainfuck loop finding
 
-(defun findOpen (len program pos depth)
-  (let ((ch (nth program pos)))
-    (if (= ch #\])
-        (findOpen len program (- pos 1) (+ depth 1))
+(defun buildJumps (program)
+  (buildJumpsRec program 0 nil nil))
+
+
+(defun buildJumpsRec (program pos stack result)
+  (if (= pos (length program))
+      result
+
+      (let ((ch (nth program pos)))
         (if (= ch #\[)
-            (if (= depth 1)
-                pos
-                (findOpen len program (- pos 1) (- depth 1)))
-            (findOpen len program (- pos 1) depth)))))
+            ;; push position
+            (buildJumpsRec
+                program
+                (+ pos 1)
+                (cons pos stack)
+                result)
 
+            (if (= ch #\])
+                (let ((open (car stack)))
+                    (buildJumpsRec
+                        program
+                        (+ pos 1)
+                        (cdr stack)
+                        (cons (list open pos) result)))
 
-(defun findClose (len program pos depth)
-  (let ((ch (nth program pos)))
-    (if (= ch #\[)
-        (findClose len program (+ pos 1) (+ depth 1))
-        (if (= ch #\])
-            (if (= depth 1)
-                pos
-                (findClose len program (+ pos 1) (- depth 1)))
-            (findClose len program (+ pos 1) depth)))))
+                (buildJumpsRec
+                    program
+                    (+ pos 1)
+                    stack
+                    result))))))
 
-
+(defun findJump (table pos)
+    (if table
+        (let ((pair (car table)))
+            (if (= (car pair) pos)
+                (car (cdr pair))
+                (if (= (car (cdr pair)) pos)
+                    (car pair)
+                    (findJump (cdr table) pos))))
+        nil))
 
 ;;; Interpreter
 
 (defun run (program)
-  (let ((i 0)                     ; offset into program
-        (len (length program))    ; length of program
-        (ptr 0)                   ; PTR value
-        (cells (makeCells 1000))) ; cells.
+  (let ((i 0)                         ; offset into program
+        (len (length program))        ; length of program
+        (ptr 0)                       ; PTR value
+        (cells (makeCells 1000))      ; cells.
+        (jumps (buildJumps program))) ; jumps
 
     ; while we've not run off the end of the program
     (while (< i len)
@@ -65,16 +75,12 @@
 
           ;; +
           ((= ins #\+) (do
-                        (set! cells
-                              (setNth cells ptr
-                                      (% (+ (nth cells ptr) 1) 256)))
+                        (setnth cells ptr (% (+ (nth cells ptr) 1) 256))
                         (set! i (+ i 1))))
 
           ;; -
           ((= ins #\-) (do
-                        (set! cells
-                              (setNth cells ptr
-                                      (% (- (nth cells ptr) 1) 256)))
+                        (setnth cells ptr (% (- (nth cells ptr) 1) 256))
                         (set! i (+ i 1))))
 
           ;; >
@@ -87,17 +93,18 @@
                         (set! ptr (- ptr 1))
                         (set! i (+ i 1))))
 
+
           ;; [
           ((= ins #\[)
            (if (= (nth cells ptr) 0)
-               (set! i (+ (findClose len program (+ i 1) 1) 1))
+               (set! i (+ (findJump jumps i) 1))
                (set! i (+ i 1))))
 
           ;; ]
           ((= ins #\])
            (if (= (nth cells ptr) 0)
                (set! i (+ i 1))
-               (set! i (+ (findOpen len program (- i 1) 1) 1))))
+               (set! i (+ (findJump jumps i) 1))))
 
           ;; ,
           ((= ins #\.) (do
@@ -106,9 +113,7 @@
 
           ;; ,
           ((= ins #\,) (do
-                        (set! cells
-                              (setNth cells ptr
-                                      (% (getc) 256)))
+                        (setnth cells ptr (% (getc) 256))
                         (set! i (+ i 1))))
 
           ;; skip over unknown instructions

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -1224,7 +1224,7 @@ FUNC fn_not
 FUNC fn_nth
     mov rbx,rdi                 ; type-check arg1: list
     GET_TAG_BITS rbx
-    cmp rbx,TAG_ID_INTEGER
+    cmp rbx,TAG_ID_CONS
     jne type_error
 
     mov rbx,rsi                 ; type-check arg2: index
@@ -1320,7 +1320,7 @@ FUNC fn_random
 FUNC fn_setnth
     mov rbx,rdi                ; arg1: list
     GET_TAG_BITS rbx
-    cmp rbx,TAG_ID_INTEGER
+    cmp rbx,TAG_ID_CONS
     jne type_error
 
     mov rbx,rsi                ; arg2: index

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -1220,6 +1220,48 @@ FUNC fn_not
 
 
 
+;; Get the Nth item from the list
+FUNC fn_nth
+    mov rbx,rdi                 ; type-check arg1: list
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_INTEGER
+    jne type_error
+
+    mov rbx,rsi                 ; type-check arg2: index
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_INTEGER
+    jne type_error
+
+    UNTAG_REG rsi
+
+.loop:
+    test rsi,rsi
+    jz .done
+
+    mov rbx,rdi                  ; nil then we're outside the bounds
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_NIL
+    je .fail
+
+    mov rbx,rdi                  ; still a list?  Good
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_CONS
+    jne type_error
+
+    UNTAG_REG rdi
+
+    mov rdi,[rdi+8]              ; point to the cdr, and loop again
+    dec rsi
+    jmp .loop
+.done:
+    UNTAG_REG rdi                ; untag the pointer
+    mov rax,[rdi]                ; get the item from the CDR
+    ret                          ; return it
+.fail:
+    jmp out_of_range
+
+
+
 ;; ord - convert a character to an integer.
 FUNC fn_ord
     mov rbx, rdi
@@ -1271,6 +1313,51 @@ FUNC fn_random
     mov rax, rdx
     TAG_INTEGER_REG rax
     ret
+
+
+
+;; Update the Nth list item, leaving everything else as-is.
+FUNC fn_setnth
+    mov rbx,rdi                ; arg1: list
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_INTEGER
+    jne type_error
+
+    mov rbx,rsi                ; arg2: index
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_INTEGER
+    jne type_error
+
+    ; cannot usefully type-check the third arg as that
+    ; could be anything.
+
+    UNTAG_REG rsi
+
+.loop:
+    test rsi,rsi
+    jz .done
+
+    mov rbx,rdi                ; nil then we're trying to update outside the bounds
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_NIL
+    je .fail
+
+    mov rbx,rdi                ; panic at the disco
+    GET_TAG_BITS rbx
+    cmp rbx,TAG_ID_CONS
+    jne type_error
+
+    UNTAG_REG rdi
+
+    mov rdi,[rdi+8]            ; cdr -> around the loop again.
+    dec rsi
+    jmp .loop
+.done:
+    UNTAG_REG rdi
+    mov [rdi], rdx             ; update car
+    ret
+.fail:
+    jmp out_of_range
 
 
 
@@ -1584,17 +1671,30 @@ FUNC fn_strlen
 
 
 
-section .text.type_error,"ax",@progbits
-
-type_error:
-    mov rdi, type_error_msg
+section .text.out_of_range,"ax",@progbits
+out_of_range:
+    mov rdi, out_of_range_msg            ; show the error
     TAG_STRING_REG rdi
     call fn_printstr
-    mov rdi, qword [rel last_function]
+    mov rdi, qword [rel last_function]   ; and the function-name
     TAG_STRING_REG rdi
     call fn_printstr
     call fn_newline
-    mov rdi, 1              ; exit-code
+    mov rdi, 1                           ; exit-code
+    jmp fn_exit
+
+
+section .text.type_error,"ax",@progbits
+
+type_error:
+    mov rdi, type_error_msg              ; show the error
+    TAG_STRING_REG rdi
+    call fn_printstr
+    mov rdi, qword [rel last_function]   ; and the function-name
+    TAG_STRING_REG rdi
+    call fn_printstr
+    call fn_newline
+    mov rdi, 1                           ; exit-code
     jmp fn_exit
 
 
@@ -1611,6 +1711,12 @@ align 8
 nil_str:
      db `<nil>`
      db 0x00
+
+;; error message for setNth
+align 8
+out_of_range_msg:
+        db `Out of bounds access.  Aborted inside `
+        db 00
 
 ;; error message for type-errors
 align 8

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -225,12 +225,6 @@ Incrementing by the given step each time."
        (fn n)
        (repeat (- n 1) fn))))
 
-(defun nth (xs n)
-  "Return the Nth item from the specified list"
-  (if (= n 0)
-    (car xs)
-    (nth (cdr xs) (- n 1))))
-
 
 (defun map (fn xs)
   "Create a new list by calling the given function for every list element."

--- a/test/list.lisp
+++ b/test/list.lisp
@@ -38,4 +38,20 @@
   ; Add a separator is nice.
   (println (join-by (list "1" "2" "3" "4" "5" "6") ","))
 
+  (let ((n (list 10 20 30 40 50)))
+    (print "List : ")
+    (println n)
+    (print "0 :")
+    (println (nth n 0))
+    (print "1 :")
+    (println (nth n 1))
+    (print "2 :")
+    (println (nth n 2))
+
+    (setnth n 0 "Steve")
+    (setnth n 1 "says")
+    (setnth n 2 "hello")
+    (print "List updated : ")
+    (println n))
+
 )

--- a/test/list.test.expected
+++ b/test/list.test.expected
@@ -11,3 +11,8 @@ I was called by repeat: 2
 I was called by repeat: 1
 This is a test of joining strings!
 1,2,3,4,5,6
+List : (10 20 30 40 50)
+0 :10
+1 :20
+2 :30
+List updated : (Steve says hello 40 50)


### PR DESCRIPTION
The `nth` implementation was moved from a (recursive) slisp primitive to an assembly one, and `setnth` was added to the standard library in assembly too.

The intent behind this is to update the brainfuck.lisp example to be faster and better, without the need to constantly update and replace the memory cells on many instructions it should perform much better - even though the list-iteration is still going to be O(n) for the pointer-chasing.

Once complete this will close #106.

* [x] move `nth` to an assembly primitive.
* [x] add `setnth` as an assembly primitive.
* [x] add test-cases.
* [x] update PRIMITIVES.md.
* [x] Update brainfuck interpreter.