### PR TITLE
Added split-all

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -130,6 +130,9 @@ Note that functions have their names mangled a little bit ("-" is converted to "
     * The list is updated in-place.
   * `split`
     * Split a string by the given character, and return a list of "(before after)".  Return nil if the character isn't found.
+  * `split-all`
+    * Return a list of all parts of string, split by the character.
+    * e.g. `(split-all (getenv "PATH") #\:)` to find all directories on the PATH.
   * `strcat`
     * Join two strings together and return them.
   * `strcmp`

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -255,6 +255,24 @@ Incrementing by the given step each time."
   "Reverse the contents of the specified list."
   (reverse-inner xs nil))
 
+(defun split-all (str char)
+  "Return a list of splitting the string by the given character.
+
+  Empty parts are ignored."
+  (if (or (nil? str) (= str ""))
+      nil
+      (filter (split-all-helper str char) (lambda (x) (> (length x) 0)))))
+
+(defun split-all-helper (str char)
+  "Recursive helper for splitting a list by character."
+  (let ((parts (split str char)))
+    (if (nil? parts)
+        (list str)
+        (cons (nth parts 0)
+              (split-all-helper (nth parts 1) char)))))
+
+
+
 
 ;;; system functions
 


### PR DESCRIPTION
Added a new `split-all` function, to use the existing `split` function and apply it recursively to make a list of all the parts of a string separated by the given character.