### PR TITLE
Rename `setnth` to `nth!`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ slisp: main.go
 # clean everything
 clean:
 	rm -f slisp $(PROGRAMS) *.asm *.o
-	cd test && make clean
+	cd test     && make clean
+	cd examples && make clean
 
 
 #

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -129,6 +129,9 @@ Note that functions have their names mangled a little bit ("-" is converted to "
     * If the value is `nil` return 1, otherwise return `nil`.
   * `nth`
     * Return the Nth item from the given list.
+  * `nth!`
+    * Update the Nth item in the given list with the specified value.
+    * The list is updated in-place.
   * `ord`
     * Return the ASCII code of the specified character.
   * `putc`
@@ -143,9 +146,6 @@ Note that functions have their names mangled a little bit ("-" is converted to "
     * Return a random integer between zero and N.
   * `rmdir`
     * Remove the named directory.
-  * `setnth`
-    * Update the Nth item in the given list with the specified value.
-    * The list is updated in-place.
   * `split`
     * Split a string by the given character, and return a list of "(before after)".  Return nil if the character isn't found.
   * `split-all`

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -378,8 +378,12 @@ func (c *Compiler) asmName(name string) string {
 		return "strp"
 	}
 
-	// allow "-" by rewriting it to _.
+	// Rewrite some names to avoid errors from nasm.
+	// e.g. creating function "foo:bar" would try to
+	// define a label "foo:bar:" and that would be rejected.
 	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, ":", "_")
+	name = strings.ReplaceAll(name, "!", "BANG")
 
 	// other functions just get "fn_" prefix
 	if strings.HasPrefix(name, "fn_") {

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -1580,7 +1580,7 @@ FUNC fn_rmdir
 
 
 ;; Update the Nth list item, leaving everything else as-is.
-FUNC fn_setnth
+FUNC fn_nthBANG
     mov rbx,rdi                ; arg1: list
     GET_TAG_BITS rbx
     cmp rbx,TAG_ID_CONS

--- a/examples/brainfuck.lisp
+++ b/examples/brainfuck.lisp
@@ -75,12 +75,12 @@
 
           ;; +
           ((= ins #\+) (do
-                        (setnth cells ptr (% (+ (nth cells ptr) 1) 256))
+                        (nth! cells ptr (% (+ (nth cells ptr) 1) 256))
                         (set! i (+ i 1))))
 
           ;; -
           ((= ins #\-) (do
-                        (setnth cells ptr (% (- (nth cells ptr) 1) 256))
+                        (nth! cells ptr (% (- (nth cells ptr) 1) 256))
                         (set! i (+ i 1))))
 
           ;; >
@@ -113,7 +113,7 @@
 
           ;; ,
           ((= ins #\,) (do
-                        (setnth cells ptr (% (getc) 256))
+                        (nth! cells ptr (% (getc) 256))
                         (set! i (+ i 1))))
 
           ;; skip over unknown instructions

--- a/test/list.lisp
+++ b/test/list.lisp
@@ -48,9 +48,9 @@
     (print "2 :")
     (println (nth n 2))
 
-    (setnth n 0 "Steve")
-    (setnth n 1 "says")
-    (setnth n 2 "hello")
+    (nth! n 0 "Steve")
+    (nth! n 1 "says")
+    (nth! n 2 "hello")
     (print "List updated : ")
     (println n))
 


### PR DESCRIPTION
This matches the naming scheme used by `set!` and feels cleaner.

This closes #129.