### PR TITLE
Allow storing lambdas in global variables

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -460,11 +460,27 @@ func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 				c.emitln("call rax")
 
 				return nil
-			} else {
-				// defun
-				c.emitln("    call " + c.asmName(symbol.Name))
+			}
+
+			// Similar story here - a lambda that is stored in a global
+			// variable instead of a local one
+			if _, ok := c.globals[symbol.Name]; ok {
+
+				// get the address
+				c.emitln(fmt.Sprintf("    mov rax,[%s]  ; %s", c.addThing("global", symbol.Name), symbol.Name))
+
+				// call lambda
+				c.emitln("UNTAG_REG rax")
+				c.emitln("mov r15, rax")
+				c.emitln("mov rax, [r15]")
+				c.emitln("call rax")
+
 				return nil
 			}
+
+			// OK then we assume it's a function
+			c.emitln("    call " + c.asmName(symbol.Name))
+			return nil
 		}
 
 		//

--- a/examples/globals.lisp
+++ b/examples/globals.lisp
@@ -6,7 +6,7 @@
 ;; Attempting to change this will generate an error at compile-time.
 (defconst bar "i am unchanging")
 
-(defun foo ()
+(defun local ()
   "Test scoping by having a local variable with the same name as a global.
 
 Spoiler: Local variable always comes first."
@@ -31,7 +31,7 @@ Spoiler: Local variable always comes first."
   (println "updated global variable is now:" foo)
 
   ;; Call a local function
-  (foo)
+  (local)
 
   (println "Global variable untouched:" foo)
 

--- a/test/list.lisp
+++ b/test/list.lisp
@@ -1,3 +1,5 @@
+(defvar by-five (lambda (x) (* x 5)))
+
 (defun main ()
   (let ((lst (list 3 4 5 (list 5 2 1) (list 3 12 99))))
     (print "Original list: ")
@@ -26,7 +28,7 @@
     (println me)
   )
 
-  (repeat 5 (lambda (n) (print "I was called by repeat: ") (println n)))
+  (repeat 5 (lambda (n) (println "I was called by repeat: " n)))
 
   (println (join (list "This"
                        " is "
@@ -53,5 +55,9 @@
     (nth! n 2 "hello")
     (print "List updated : ")
     (println n))
+
+  ; Lambda in global variable
+  (let ((x (list 1 2 3 4 5)))
+    (println (map by-five x)))
 
 )

--- a/test/list.test.expected
+++ b/test/list.test.expected
@@ -16,3 +16,4 @@ List : (10 20 30 40 50)
 1 :20
 2 :30
 List updated : (Steve says hello 40 50)
+(5 10 15 20 25)


### PR DESCRIPTION
Allow storing lambda in global variable.
    
I'm not sure why that would want to be done, but it can be.  Added a `map` example of using such a thing, to prove it works.  I guess some kinda map/sort function might be reused within a program so it might make sense to make it global.
    
This closes #130.
