### PR TITLE
Ensure we have sane return values from stdlib functions

### DIFF
--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -647,6 +647,8 @@ fn_newline:
     mov byte [rsi], 10      ; add a newline character there
     mov rdx, 1
     syscall
+    xor rax,rax             ; return nil
+    TAG_NIL_REG rax
     ret
 
 
@@ -834,6 +836,9 @@ fn_printstr:
     mov rax, SYS_write
     mov rdi, 1                ; stdout
     syscall
+
+    xor rax,rax               ; return nil
+    TAG_NIL_REG rax
     ret
 
 
@@ -1521,13 +1526,15 @@ FUNC fn_ord
 ;; Write the given ASCII character to STDOUT
 FUNC fn_putc
     mov rax, rdi
+    push rax
     UNTAG_REG rax
     mov [random_buffer],  al  ; store character
     mov rax, SYS_write
     mov rdi, 1                ; STDOUT
     mov rsi, random_buffer
-    mov rdx, 1              ; 1 byte
+    mov rdx, 1                ; 1 byte
     syscall
+    pop rax                   ; This is the tagged input value
     ret
 
 
@@ -1618,6 +1625,7 @@ FUNC fn_nthBANG
 .done:
     UNTAG_REG rdi
     mov [rdi], rdx             ; update car
+    mov rax, rdx               ; return value is the thign we set
     ret
 .fail:
     jmp out_of_range


### PR DESCRIPTION
This pull-request closes #133 by ensuring that functions such as `nth!`, `println`, `putc`, etc, return tagged values.

If a function returns a "random" function then there is a chance that we'll later assume it is tagged, and then untag it and attempt to use it in a broken way - leading to segfaults aplenty.