### PR TITLE
Improve our lexer to allow escape-quotes in strings.

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,13 +1,8 @@
-// Package lexer contains our trivial lexer code.
+// Package lexer contains code to convert our input program into a series of tokens.
 //
-// As lisp is so minimal this is as basic as could be, we only have to worry about
-// comments, strings, and nothing else.
-//
-// We build up characters into an internal reader and just stop when
-// we see "(", ")", "newline", etc.  Character literals, comments
-// and strings are peeled off ahead of that.
-//
-// TODO: Better.
+// As lisp is so minimal this package is as basic as it could be; we only really have
+// to care about strings, character literals and comments.  Everything else is either
+// a symbol or parenthesis characters.
 package lexer
 
 import (
@@ -17,120 +12,202 @@ import (
 
 // Lexer holds our state.
 type Lexer struct {
+
 	// input contains the string we're going to lex into tokens.
 	input string
+
+	// pos records our current position.
+	pos int
 }
 
-// New is our constructor, which creates a new lexer from a given input source.
+// New creates a new lexer object
 func New(src string) *Lexer {
 	return &Lexer{
 		input: src,
 	}
 }
 
-// Tokenize is the method that returns an array of tokens from the given
-// source.
+// Tokenize returns the tokenized version of the input string passed to our constructor.
 func (l *Lexer) Tokenize() ([]string, error) {
 	var out []string
-	var cur strings.Builder
 
-	flush := func() {
-		if cur.Len() > 0 {
-			val := cur.String()
-			if strings.HasPrefix(val, ":") {
-				val = val[1:]
-				val = "\"" + val + "\""
-			}
-			out = append(out, val)
-			cur.Reset()
-		}
-	}
+	for !l.eof() {
 
-	inComment := false
-	inString := false
+		switch l.peek() {
 
-	for i := 0; i < len(l.input); i++ {
-		ch := l.input[i]
-
-		// Note that we do no processing of "\n" to newline, etc.
-		//
-		// That is deferred to nasm.
-		if inString {
-			if ch == '"' {
-				cur.WriteByte(ch)
-				out = append(out, cur.String())
-				cur.Reset()
-				inString = false
-				continue
-			}
-			cur.WriteByte(ch)
-			continue
-		}
-
-		// comment start at ";" and end at the end of the line
-		if inComment {
-			if ch == '\n' {
-				inComment = false
-			}
-			continue
-		}
-
-		// A bit ugly, but we test #\xx specially here
-		// because otherwise "#\(" wouldn't be possible
-		// as we regard "(" and ")" as separators.
-		if ch == '#' &&
-			i+1 < len(l.input) &&
-			l.input[i+1] == '\\' {
-
-			flush()
-
-			cur.WriteByte('#')
-			cur.WriteByte('\\')
-			i += 2
-
-			if i >= len(l.input) {
-				return nil, fmt.Errorf("unterminated character literal")
-			}
-
-			cur.WriteByte(l.input[i])
-
-			if l.input[i] == '\\' {
-				i++
-				if i >= len(l.input) {
-					return nil, fmt.Errorf("unterminated escape")
-				}
-				cur.WriteByte(l.input[i])
-			}
-
-			out = append(out, cur.String())
-			cur.Reset()
-			continue
-		}
-
-		// obvious stuff
-		switch ch {
-
-		case '(', ')':
-			flush()
-			out = append(out, string(ch))
-
-		case '"':
-			flush()
-			cur.WriteByte(ch)
-			inString = true
-
-		case ' ', '\n', '\r', '\t':
-			flush()
+		case ' ', '\t', '\n', '\r':
+			l.skipWhitespace()
 
 		case ';':
-			flush()
-			inComment = true
+			l.skipComment()
+
+		case '(':
+			l.next()
+			out = append(out, "(")
+
+		case ')':
+			l.next()
+			out = append(out, ")")
+
+		case '"':
+			str, err := l.scanStringLiteral()
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, str)
+
+		case '#':
+			tok, err := l.scanCharacterLiteral()
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, tok)
 
 		default:
-			cur.WriteByte(ch)
+			out = append(out, l.scanSymbol())
 		}
 	}
 
-	flush()
 	return out, nil
+}
+
+// scanStringLiteral is called to consume a string literal, and return it.
+func (l *Lexer) scanStringLiteral() (string, error) {
+	var b strings.Builder
+
+	// We've already seen '"'
+	if l.next() != '"' {
+		return "", fmt.Errorf("scanStringLiteral called at wrong position")
+	}
+
+	// opening quote
+	b.WriteByte('"')
+
+	for !l.eof() {
+
+		ch := l.next()
+
+		switch ch {
+
+		case '\\':
+			b.WriteByte(ch)
+
+			if l.eof() {
+				return "", fmt.Errorf("unterminated escape sequence in string")
+			}
+
+			b.WriteByte(l.next())
+
+		case '"':
+			b.WriteByte(ch)
+			return b.String(), nil
+
+		default:
+			b.WriteByte(ch)
+		}
+	}
+
+	return "", fmt.Errorf("unterminated string")
+}
+
+// scanCharacterLiteral is invoked to parse a character literal, i.e. something prefixed with #\.
+func (l *Lexer) scanCharacterLiteral() (string, error) {
+
+	// We've already seen '#'
+	if l.next() != '#' {
+		return "", fmt.Errorf("scanCharacterLiteral called at wrong position")
+	}
+
+	if l.eof() || l.next() != '\\' {
+		return "", fmt.Errorf("expected '\\' after '#'")
+	}
+
+	var b strings.Builder
+	b.WriteString("#\\")
+
+	if l.eof() {
+		return "", fmt.Errorf("unterminated character literal")
+	}
+
+	ch := l.next()
+	b.WriteByte(ch)
+
+	// Allow escaped characters such as #\\ or #\"
+	if ch == '\\' {
+		if l.eof() {
+			return "", fmt.Errorf("unterminated escape")
+		}
+		b.WriteByte(l.next())
+	}
+
+	return b.String(), nil
+}
+
+// scanSymbol is invoked to parse a symbol.
+func (l *Lexer) scanSymbol() string {
+	var b strings.Builder
+
+	for !l.eof() {
+
+		switch l.peek() {
+		case ' ', '\t', '\n', '\r', ';', '(', ')':
+			goto done
+
+		default:
+			b.WriteByte(l.next())
+		}
+	}
+
+done:
+
+	s := b.String()
+
+	// :-prefixed symbols become strings.
+	if strings.HasPrefix(s, ":") {
+		return `"` + s[1:] + `"`
+	}
+
+	return s
+}
+
+// skipWhitespace skips over any whitespace.
+func (l *Lexer) skipWhitespace() {
+	for !l.eof() {
+		switch l.peek() {
+		case ' ', '\t', '\n', '\r':
+			l.next()
+		default:
+			return
+		}
+	}
+}
+
+// skipComment moves our lexer over any comment.
+//
+// Comments start with ";" and continue until the end of the line.
+func (l *Lexer) skipComment() {
+	for !l.eof() && l.peek() != '\n' {
+		l.next()
+	}
+}
+
+// eof tests if we've exceeded the length of our input
+func (l *Lexer) eof() bool {
+	return l.pos >= len(l.input)
+}
+
+// peek returns the next character which will be encountered, without consuming it or moving
+// our position forward.
+func (l *Lexer) peek() byte {
+	if l.eof() {
+		return 0
+	}
+	return l.input[l.pos]
+}
+
+// next advances our position and returns the next character to be processed.
+func (l *Lexer) next() byte {
+	ch := l.peek()
+	l.pos++
+	return ch
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -4,6 +4,55 @@ import (
 	"testing"
 )
 
+// TestString makes various tests against strings
+func TestString(t *testing.T) {
+
+	// happy path
+	l := New(`"Hello, world!"`)
+
+	str, err := l.scanStringLiteral()
+	if err != nil {
+		t.Fatalf("expected no error, got one %s", err)
+	}
+	if str != "\"Hello, world!\"" {
+		t.Fatalf("got wrong result: %s", str)
+	}
+
+	// happy path with quotes
+	l = New(`" Hello \"Steve\" "`)
+
+	str, err = l.scanStringLiteral()
+	if err != nil {
+		t.Fatalf("expected no error, got one %s", err)
+	}
+	if str != `" Hello \"Steve\" "` {
+		t.Fatalf("got wrong result: %s", str)
+	}
+
+	// unterminated string
+	l = New(`"Hello, world!`)
+
+	_, err = l.scanStringLiteral()
+	if err == nil {
+		t.Fatalf("expected [unterminated string] error, got none")
+	}
+
+	// unterminated escape
+	l = New(`"Hello, world!\`)
+
+	_, err = l.scanStringLiteral()
+	if err == nil {
+		t.Fatalf("expected [unterminated escape] error, got none")
+	}
+
+	// not a string (can't happen)
+	l = New(`meh`)
+	_, err = l.scanStringLiteral()
+	if err == nil {
+		t.Fatalf("expected [not a string] error, got none")
+	}
+}
+
 func TestWhitespace(t *testing.T) {
 
 	l := New("         \t\n\r")
@@ -30,7 +79,12 @@ func TestComment(t *testing.T) {
 }
 
 func TestBasic(t *testing.T) {
+	// valid program
 	l := New(`
+(println 3.1)
+(println "This is " pi )
+(println "I fake symbols " :symbol)
+
 (if nil
   (message "fatal error")
  (message "This is fine."))`)
@@ -39,8 +93,17 @@ func TestBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error tokenizing")
 	}
-	if len(out) != 12 {
+	if len(out) != 26 {
 		t.Fatalf("unexpected lexer result %d - %v", len(out), out)
+	}
+
+	// broken program - string error
+	l = New(`
+(println "This is never complete`)
+
+	_, err = l.Tokenize()
+	if err == nil {
+		t.Fatalf("expected error, saw none")
 	}
 }
 
@@ -50,6 +113,7 @@ func TestCharacterLiteral(t *testing.T) {
 	test := []string{
 		`#\`,
 		`#\\`,
+		`#x`,
 	}
 
 	for _, tst := range test {
@@ -79,6 +143,24 @@ func TestCharacterLiteral(t *testing.T) {
 		if len(out) != 1 {
 			t.Fatalf("unexpected lexer result %d - %v", len(out), out)
 		}
+	}
+
+	// not a character literal (can't happen)
+	l := New(`meh`)
+	_, err := l.scanCharacterLiteral()
+	if err == nil {
+		t.Fatalf("expected [not a character] error, got none")
+	}
+
+}
+
+func TestEOF(t *testing.T) {
+	l := New(``)
+	i := 0
+	for i < 10 {
+		l.peek()
+		l.next()
+		i++
 	}
 
 }


### PR DESCRIPTION
This pull-request updates our lexer to be much more ideomatic, and adds the feature which triggered this refactoring: the ability to escape quotes in strings.

As we defer our strings to `nasm` we mostly don't care about their contents, things like "\n" just work.  Because of that I'd neglected any kinda of special escape-handling support which meant this was broken:

        (print "My greeting is \"hello, world!\".")

Now it works, and test-coverage has been bumped to 100% to avoid any obvious regressions.