### PR TITLE
Implement `system`.

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -167,6 +167,8 @@ Note that functions have their names mangled a little bit ("-" is converted to "
      * Everything else returns an empty string.
   * `strlen`
     * Return the length of the given string.
+  * `sys_run`
+    * Helper for command execution.
   * `unlink`
     * Delete the named file.
 
@@ -285,6 +287,8 @@ The implementation of these primitives can be found in the file [stdlib.slisp](s
   * Return a substring from a given string.
 * `sum`
   * Sum the values in the given list.
+* `system`
+  * Run a command via `sys_run`,  return the output on success, and nil on failure.
 * `upper`
   * Return the given string, converted to upper-case.
 * `which`

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -36,7 +36,11 @@ SYS_open        equ 2
 SYS_close       equ 3
 SYS_stat        equ 4
 SYS_lseek       equ 8
+SYS_dup2        equ 33
+SYS_fork        equ 57
+SYS_exec        equ 59
 SYS_exit        equ 60
+SYS_wait4       equ 61
 SYS_mkdir       equ 83
 SYS_rmdir       equ 84
 SYS_unlink      equ 87
@@ -2084,6 +2088,101 @@ FUNC fn_strlen
     ret
 
 
+;; system helper
+FUNC fn_sys_run
+    mov rbx, rdi               ; type check
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+    mov rbx, rsi               ; type check
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+
+    UNTAG_REG rdi
+    UNTAG_REG rsi
+
+    mov r12, rdi            ; command
+    mov r13, rsi            ; output filename
+
+    mov eax, SYS_fork
+    syscall
+    test rax, rax
+    js .error
+    jz .child
+
+.parent:
+    mov r14, rax            ; child pid
+    sub rsp, 16
+    mov edi, r14d           ; pid
+    mov rsi, rsp            ; &status
+    xor edx, edx            ; options = 0
+    xor r10, r10            ; rusage = NULL
+    mov eax, SYS_wait4
+    syscall
+
+    mov eax, [rsp]          ; exit code
+    and eax, 0xff00
+    shr eax, 8
+
+    add rsp, 16
+    TAG_INTEGER_REG rax
+    ret
+
+.child:
+    mov eax, SYS_open
+    mov rdi, r13
+    mov esi, 577            ; O_WRONLY|O_CREAT|O_TRUNC
+    mov edx, 0600o
+    syscall
+
+    test rax, rax
+    js .child_fail
+
+    mov r14, rax            ; fd
+
+    mov eax, SYS_dup2       ; STDOUT
+    mov rdi, r14
+    mov esi, 1
+    syscall
+
+    mov eax, SYS_dup2       ; STDERR
+    mov rdi, r14
+    mov esi, 2
+    syscall
+
+    mov eax, SYS_close
+    mov rdi, r14
+    syscall
+
+    ;;
+    ;; argv[] = { "/bin/sh", "-c", command, NULL }
+    ;;
+    sub rsp, 32
+    lea rax, [rel shell_path]
+    mov [rsp], rax
+    lea rax, [rel dash_c]
+    mov [rsp+8], rax
+    mov [rsp+16], r12
+    mov qword [rsp+24], 0
+
+    mov eax, SYS_exec
+    lea rdi, [rel shell_path]
+    mov rsi, rsp
+    mov rdx, [rel envp_ptr]
+    syscall
+
+.child_fail:
+    mov edi, 127
+    mov eax, SYS_exit
+    syscall
+
+.error:
+    xor rax, rax
+    TAG_NIL_REG rax
+    ret
+
+
 ;; Delete the given file.
 FUNC fn_unlink
     mov rbx, rdi
@@ -2168,6 +2267,17 @@ million:
 align 8
 minusmask:
         dq 0x8000000000000000
+
+;; Used by sys_run
+align 8
+shell_path:
+    db "/bin/sh",0
+
+;; Used by sys_run
+align 8
+dash_c:
+    db "-c",0
+
 
 ;; buffer for our random function to read into.
 ;; other functions, such as getc, newline, use it

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -2284,10 +2284,9 @@ dash_c:
 ;; too.  Because why not?
 align 8
 random_buffer:
-    db `skx!`
     db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-    db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    db `https://github.com/skx/slisp`
     db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 random_buffer_end:

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -464,6 +464,17 @@ Incrementing by the given step each time."
             (getenv-loop name (cdr xs))))
       nil))
 
+(defun system(cmd)
+  "Run a command and return the output; nil on failure."
+  (let ((tmp     "/tmp/mktmp")         ; tmp file for output
+        (res     (sys_run cmd tmp))    ; run command
+        (handle  (fopen tmp "r"))      ; open file
+        (data    (fread handle))       ; read output
+        (ignore1 (fclose handle))      ; close file
+        (ignore2 (unlink tmp)))        ; delete temporary file
+    (if (= 0 res)                      ; return either data, or nil
+        data
+        nil)))
 
 
 


### PR DESCRIPTION
This closes #149 by introducing a new primitive `sys_run` which accepts a command to execute and the filename to which the output should be written.

Using that I've implemented this nifty `system` wrapper:

```lisp
(defun system(cmd)
  "Run a command and return the output; nil on failure."
  (let ((tmp     "/tmp/mktmp")         ; tmp file for output
        (res     (sys_run cmd tmp))    ; run command
        (handle  (fopen tmp "r"))      ; open file
        (data    (fread handle))       ; read output
        (ignore1 (fclose handle))      ; close file
        (ignore2 (unlink tmp)))        ; delete temporary file
    (if (= 0 res)                      ; return either data, or nil
        data
        nil)))
```

That's actually really cool.  Albeit a security hole; I need fn_mktemp.