### PR TITLE
Added argument-parser package.

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -302,6 +302,8 @@ Here's how it might be used:
 (println (+ 3 4 5 6 7))
 ```
 
+We have a simple argument-parser located in [packages/arg-parser.lisp](packages/arg-parser.lisp) which you can see demonstrated in the [examples/wc.lisp](examples/wc.lisp) sample program.
+
 
 
 ## See Also

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can find bigger examples beneath [examples/](examples/), and our [test/](tes
   * [examples/packages.lisp](examples/packages.lisp) demonstrates how our packaging system works - more details in [INTRODUCTION.md](INTRODUCTION.md).
   * [examples/globals.lisp](examples/globals.lisp) - Explicit demonstration of scopes, showing that local variables always take precedence over global ones.
   * [examples/nqueens.lisp](examples/nqueens.lisp) is a solver for the N Queens problem, defaults to solving the 8x8 grid but you may specify different sizes via a CLI argument.
+  * [examples/wc.lisp](examples/wc.lisp) is a clone of the standard `wc` utility, which demonstrates our included argument-parser [packages/](package/).
 
 * Notable tests:
   * [test/entries.lisp](test/entries.lisp) - Read all the files in a directory, filter them, sort them, and print their names.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,3 +23,4 @@ This directory is designed to contain bigger, or more interesting examples, than
   * How to refer to functions/globals in another package, via qualifiers.
 * [wc.lisp](wc.lisp) - Clone of the Unix "wc" command.
   * Shows lines, characters, and words for named files.
+  * Demonstrates the use of our CLI argument parsing package; [../packages/arg-parser.lisp](../packages/arg-parser.lisp)

--- a/examples/args.lisp
+++ b/examples/args.lisp
@@ -1,0 +1,5 @@
+    (require arg-parser)
+    (defun main(args)
+      (let ((parser (arg-parser:new (cdr args))))
+        (println "Flags " (parser :flags))
+        (println "Files " (parser :files))))

--- a/examples/args.test.expected
+++ b/examples/args.test.expected
@@ -1,0 +1,2 @@
+Flags <nil>
+Files <nil>

--- a/examples/wc.lisp
+++ b/examples/wc.lisp
@@ -1,13 +1,26 @@
 ;; wc.lisp - Word Count clone
+;;
+;; NOTE: "./wc *.lisp" does NOT produce a "total" line, which is an obvious omission.
+
+
+;; Load our argument-parsing package.
+(require arg-parser)
+
+;; variables set by CLI parser.
+(defvar show-lines nil)
+(defvar show-words nil)
+(defvar show-bytes nil)
+
 
 (defun whitespace?(ch)
   "Is the given character whitespace?"
-  (or (= ch #\Space)
-      (= ch #\Tab)
-      (= ch #\Newline)))
+  (or (= ch #\Newline)
+      (= ch #\Return)
+      (= ch #\Space)
+      (= ch #\Tab)))
 
 (defun words (chars)
-  "Use reduce to sum up words. Which are things separated by whitespace"
+  "Use reduce to sum up words, which is basically a matter of matching boundaries."
   (reduce chars
         (lambda (state ch)
           (let ((count (car state))
@@ -20,21 +33,56 @@
         (cons 0 nil)))
 
 (defun show-data (data filename)
-  "Show lines/chars/words from the data - with filename too"
+  "Show lines/chars/words from the data alongside the filename"
   (let ((size  (length data))
         (chars (explode data))
         (lines (filter chars (lambda (x) (= x #\Newline)))))
-    (println (length lines) " " (car (words chars)) " " size " " filename)))
+    (if show-lines
+        (print (length lines) " "))
+
+    (if show-words
+        (print (car (words chars)) " "))
+
+    (if show-bytes
+        (print size " "))
+
+    (println filename)))
+
 
 (defun process (file)
-  "If we can open the file, read it and start processing"
+  "If we can open the file, read it and start processing."
   (let ((handle  (fopen file "r")) ; open
         (data    (fread handle))   ; read
         (discard (fclose handle))) ; close
     (if data
         (show-data data file))))
 
-
 (defun main (args)
-  "Process each specified filename, if any"
-  (map (lambda (x) (process x )) (cdr args)))
+  "Produce char/line/word stats for each named file."
+
+  (let ((parser (arg-parser:new (cdr args)))
+        (files  (parser :files)))
+
+    (map (lambda (arg)
+           (cond
+             ((or (= arg "-l") (= arg "--lines")) (set! show-lines t))
+             ((or (= arg "-c") (= arg "--bytes")) (set! show-bytes t))
+             ((or (= arg "-m") (= arg "--chars")) (set! show-bytes t))
+             ((or (= arg "-w") (= arg "--words")) (set! show-words t))
+             ((= arg "--help") (println "help"))
+             (t                (do
+                                (println "unknown arg '" arg "'")
+                                (exit 1)))))
+         (parser :flags))
+
+    ;; No options?  Behave like wc and show "everything"
+    (if (and (not show-lines)
+             (not show-words)
+             (not show-bytes))
+        (do
+          (set! show-lines t)
+          (set! show-words t)
+          (set! show-bytes t)))
+
+    ;; now process files
+    (map (lambda (x) (process x)) files)))

--- a/packages/README.md
+++ b/packages/README.md
@@ -12,6 +12,19 @@ Association list code, included as part of `stdlib.lisp`, so there is no need to
 ```
 
 
+### arg-parser
+
+A simple utility package which allows parsing command-line arguments into "flags" and "other" (named "files" on the basis that is probably what they are).
+
+Usage is demonstrated in the [examples/wc.lisp](examples/wc.lisp) utility program, but in-brief create an instance of the object:
+
+    (require arg-parser)
+    (defun main(args)
+      (let ((parser (arg-parser:new (cdr args))))
+        (print "Flags " (parser :flags))
+        (print "Files " (parser :files))))
+
+
 ### plist
 
 Property list code, included as part of `stdlib.lisp`, so there is no need to additionally require it.

--- a/packages/arg-parser.lisp
+++ b/packages/arg-parser.lisp
@@ -47,7 +47,7 @@
            "Return the flags from this argument."
            (if args
                (append
-                (flags-from-arg (car args))
+                (if (> (length (car args)) 1) (flags-from-arg (car args)) (list "-"))
                 (flags-helper (cdr args)))
                nil))
 
@@ -56,13 +56,13 @@
            (let ((chars (explode arg)))
              (cond
                ;; Not a flag.
-               ((! (= (nth chars 0) #\-))   nil)
+               ((! (= (nth chars 0) #\-)) nil)
 
-               ;; Long flag (--foo)
-               ((= (nth chars 1) #\-)      (list arg))
+                   ;; Long flag (--foo)
+                   ((= (nth chars 1) #\-) (list arg))
 
-               ;; Short flag(s): -abc -> ("-a" "-b" "-c")
-               (t                          (expand-short-flags (cdr chars))))))
+                   ;; Short flag(s): -abc -> ("-a" "-b" "-c")
+                   (t (expand-short-flags (cdr chars))))))
 
          (defun expand-short-flags (chars)
            "Given a list of short flags 'xyz' return (-x -y -z)"
@@ -71,4 +71,4 @@
                (cons (strcat "-" (string (car chars)))
                      (expand-short-flags (cdr chars)))))
 
- ) ;; end of arg-parser
+         ) ;; end of arg-parser

--- a/packages/arg-parser.lisp
+++ b/packages/arg-parser.lisp
@@ -1,0 +1,74 @@
+;;; arg-parser - Trivial arg parsing package
+;;
+;; This package makes the assumption that command
+;; line arguments have two forms:
+;;
+;;  - options prefixed with "-"
+;;    (for example "-l", "-ltr", or "--long".
+;;
+;;  - filenames with no prefix
+;;
+;; The constructor returns a lambda function which
+;; may be used to return either "flags", or "files",
+;; being the two types of argument
+;;
+;; To ease usage any short-form flags which have been
+;; merged together are split up into distinct flags
+;; so "foo -ltr" will have the flags returned as a
+;; list ("-l" "-t" "-r").
+;;
+
+(package arg-parser
+
+         ;;
+         ;; Main function - which returns a lambda
+         ;; that can retrieve either "flags" or "files".
+         ;;
+         (defun new (copy)
+           (lambda (type)
+             (cond
+               ((= type :flags) (arg-parser:flags-helper copy))
+               ((= type :files) (arg-parser:files copy))
+               (t               (do
+                                 (println "unknown mode for arg-parser lambda")
+                                 (exit 1))))))
+
+
+         ;;
+         ;; Internal helper routines
+         ;;
+         (defun files (a)
+           "Return non-flag arguments, i.e. files"
+           (filter a
+                   (lambda (arg)
+                     (! (= (nth (explode arg) 0) #\-)))))
+
+         (defun flags-helper (args)
+           "Return the flags from this argument."
+           (if args
+               (append
+                (flags-from-arg (car args))
+                (flags-helper (cdr args)))
+               nil))
+
+         (defun flags-from-arg (arg)
+           "If the given argument is a flag then handle it appropriately."
+           (let ((chars (explode arg)))
+             (cond
+               ;; Not a flag.
+               ((! (= (nth chars 0) #\-))   nil)
+
+               ;; Long flag (--foo)
+               ((= (nth chars 1) #\-)      (list arg))
+
+               ;; Short flag(s): -abc -> ("-a" "-b" "-c")
+               (t                          (expand-short-flags (cdr chars))))))
+
+         (defun expand-short-flags (chars)
+           "Given a list of short flags 'xyz' return (-x -y -z)"
+           (if (not chars)
+               nil
+               (cons (strcat "-" (string (car chars)))
+                     (expand-short-flags (cdr chars)))))
+
+ ) ;; end of arg-parser


### PR DESCRIPTION
The new package may be included via:

        (require arg-parser)

And then used to retrieve CLI flags, or "other" arguments.  This is demonstrated in examples/wc.lisp.