### PR TITLE
BUGFIX: Don't be greedy swallowing quotes

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -314,8 +314,9 @@ func (p *Parser) parseExpr() (Expr, error) {
 	}
 
 	// string
-	if strings.HasPrefix(t, "\"") {
-		return &String{Value: strings.Trim(t, "\"")}, nil
+	if strings.HasPrefix(t, "\"") && strings.HasSuffix(t, "\"") {
+		t = t[1 : len(t)-1]
+		return &String{Value: t}, nil
 	}
 
 	// integer?


### PR DESCRIPTION
In the past this failed:

        (println "\"")

The issue was the strings.Trim call was swallowing the opening quote and BOTH of the closing ones.  Now we just take one out, manually.