### PR TITLE
Introduce a **LISP INTERPRETER**, for our compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Loading .. ../test/closure2.lisp
 Welcome to lisp in slisp!
 Enter :quit to exit.
 
-> (main)
+> (main)   ; loading "closure2.lisp" will produce a (defun main) now we call it.
 25
 35
 5
@@ -222,9 +222,9 @@ Enter :quit to exit.
 40
 ```
 
-So what are the differences between our _compiler_ and our _interpreter_?  Well in some ways the interpreter is more advanced as it has support for `(quote)` and lambdas/defuns are real standalone objects which you can print.  But the biggest difference is that the compiler has a significantly larger standard-library.
+So what are the differences between our _compiler_ and our _interpreter_?  Well in some ways the interpreter is more advanced as it has support for `(quote)`, it has a symbol-type, and you can get references to functions using them.  The lambdas/defuns are real standalone objects which are treated largely interchangeably and which you can print.  But the biggest difference is that the compiler has a significantly larger standard-library.
 
-The compiler prepends [stdlib.lisp](stdlib.lisp) to all programs, so you always have `map`, `filter`, etc, available.  By contrast the interpreter has a very small standard library - it exposes `print`, `println`, `cons`, `list` and the special forms.  It understands strings, integers, and floating-point numbers but it doesn't have a character-type.
+The compiler prepends [stdlib.slisp](stdlib.slisp) to all programs, so you always have `map`, `filter`, etc, available.  By contrast the interpreter has a very small standard library - it exposes `print`, `println`, `cons`, `list` and the special forms.  It understands strings, integers, and floating-point numbers but it doesn't have a character-type.
 
 That said, and as demonstrated above, the interpreter can run many of the same programs that the compiler can.  The main omissions are mutating captured variables inside closures, and the need to enter functions all on one line if you're using the REPL.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository contains `slisp` (either named for "Steve's Lisp Compiler", or "Simple Lisp Compiler"), which is a compiler reading Lisp programs as input, generating standalone assembly representations for Linux/AMD64 as output.
 
-Lisp is traditionally interactive, and provides a REPL, which this project is not.  That said it's still a great way to execute programs, and a good project for learning (either using a compiled lisp, or implementing one).
+Lisp is traditionally used in an interactive way, via a REPL.  By contrast this repository allows you to turn a lisp program into a compiled executable which will run non-interactively.
+
+> But note that I did write a **Lisp Interpreter**, complete with a REPL, which you can see described below in the [INCEPTION](#inception) section.
 
 Quick links:
 
@@ -151,6 +153,80 @@ There is also support for the fuzz-testing that golang provides, you can run fiv
 ```sh
 $ go test -fuzztime=300s -parallel=1 -fuzz=FuzzProject -v
 ```
+
+
+
+## Inception
+
+As noted this is a _compiler_ which means that for a given lisp program we produce an executable, there is no REPL.
+
+But I thought it might be fun to prove that my slisp is a _real lisp_, and so I implemented a lisp interpreter which can read lisp source code from files and execute it, and which also implements a REPL.
+
+Build the compiler, and build the interpreter:
+
+```
+go build .
+cd examples/
+make
+```
+
+Now you should find, amongst other binaries, you have the executable `inception` which is an interpreter.  Fire it up:
+
+```
+$ ./inception --repl
+Welcome to lisp in slisp!
+Enter :quit to exit.
+
+> (defun square (x) (* x x))
+(symbol square)
+> square
+(closure (x) (((symbol *) (symbol x) (symbol x))) <nil>)
+> (square 3)
+9
+> (square (square (square 3) ) )
+6561
+> :quit
+```
+
+In addition to having a REPL you can also load files (and then optionally have the REPL start).  So here's running the self-contained example:
+
+```
+$ ./inception inception.in
+Loading .. inception.in
+100
+Squaring some numbers: (16 25 400 900 1600)
+LAMBDA X 1*1: -> 1
+LAMBDA X 2*2: -> 4
+LAMBDA X 3*3: -> 9
+LAMBDA X 4*4: -> 16
+LAMBDA X 5*5: -> 25
+This is what a function looks like: (closure (x) (((symbol +) (symbol x) (symbol n))) ((n 10)))
+Adder (+10) result for  5:15
+..
+```
+
+And here is loading an existing test - which will define the function `main` and launching that via the REPL:
+
+```
+$ ./inception ../test/closure2.lisp  --repl
+Loading .. ../test/closure2.lisp
+Welcome to lisp in slisp!
+Enter :quit to exit.
+
+> (main)
+25
+35
+5
+10
+22
+40
+```
+
+So what are the differences between our _compiler_ and our _interpreter_?  Well in some ways the interpreter is more advanced as it has support for `(quote)` and lambdas/defuns are real standalone objects which you can print.  But the biggest difference is that the compiler has a significantly larger standard-library.
+
+The compiler prepends [stdlib.lisp](stdlib.lisp) to all programs, so you always have `map`, `filter`, etc, available.  By contrast the interpreter has a very small standard library - it exposes `print`, `println`, `cons`, `list` and the special forms.  It understands strings, integers, and floating-point numbers but it doesn't have a character-type.
+
+That said, and as demonstrated above, the interpreter can run many of the same programs that the compiler can.  The main omissions are mutating captured variables inside closures, and the need to enter functions all on one line if you're using the REPL.
 
 
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -42,6 +42,16 @@ endif
 life.test:
 	@echo "ignoring $@ - as it doesn't terminate"
 
+# inception needs a file to be named
+inception.test:
+	@echo "compiling $@"
+	@../slisp inception.lisp > tmp.asm
+	@nasm -f elf64 tmp.asm
+	$(LINK_CMD)
+	@echo "testing $@"
+	@./$@ inception.in > $@.out 2>&1  || true
+	@cmp $@.out $@.expected || (echo "program $< did not match" ; cat $@.out ; exit 1)
+
 wc.test:
 	@echo "ignoring $@ - as it doesn't terminate"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,9 @@ This directory is designed to contain bigger, or more interesting examples, than
 * [example.lisp](example.lisp) - Our first example.
 * [globals.lisp](globals.lisp) - Explicit demonstration of scopes
   * Shows that local variables always take precedence over global ones.
+* [inception.lisp](inception.lisp) - A **lisp interpreter** written in slisp
+  * This can load and evaluate named files, and optionally give a REPL mode too.
+  * Run "./inception ./inception.in" to see it in operation.
 * [nqueens.lisp](nqueens.lisp) - Solver for [The N-queens problem](https://en.wikipedia.org/wiki/Eight_queens_puzzle)
   * Defaults to solving 8x8, but you can give another size as CLI argument.
 * [packages.lisp](packages.lisp) - Demonstrate the use of our `(package ..)` special form

--- a/examples/inception.in
+++ b/examples/inception.in
@@ -1,0 +1,90 @@
+;;; inception.in - Test file for lisp interpreter
+
+
+;; global variable
+(defvar x 7)
+
+;; comments are here
+(defun square (x)
+   (* x x))
+
+;; Test our square function
+(println (square 10))
+
+
+;; factorial function
+(defun fact (n)
+  (if (<= n 1)
+      1
+      (* n (fact (- n 1)))))
+
+
+;; recursion
+(defun length (xs)
+    (if (nil? xs)
+        0
+        (+ 1 (length (cdr xs)))))
+
+;; map
+(defun map (f xs)
+    (if (nil? xs)
+        nil
+        (cons
+            (f (car xs))
+            (map f (cdr xs)))))
+
+
+;;
+;; Start running some code
+;;
+(print   "Squaring some numbers: ")
+(println (map square (list 4 5 20 30 40)))
+
+;;
+;; Show that our lambda works with map, and that
+;; multiple expressions work.
+;;
+(map
+   (lambda (x) (println "LAMBDA X " x "*" x ": -> " (* x x)) (* x x))
+        (list 1 2 3 4 5))
+
+
+;;
+;; Make a closure/adder.
+;;
+(defun make-adder (n)
+    (lambda (x)
+        (+ x n)))
+
+
+(println "This is what a function looks like: " (make-adder 10))
+
+;;
+;; Create an adder, and use it
+;;
+(defvar add10 (make-adder 10))
+(println "Adder (+10) result for  5:" (add10 5))
+(println "Adder (+10) result for 25:" (add10 25))
+
+;; maths
+(println "Some maths:")
+(println "  " (+ 329 1))
+(println "  " (* 37 26))
+(println "  " (/   9 3))     ; integer division
+(println "  " (/   1.0 10))  ; need to add a ".0" suffix to force floats
+
+
+;; length tests
+(println (-  0  2 ))
+(println (- -3 -2 ))
+(println nil)
+(println (length (list )))
+(println (length (list 1)))
+(println (length (list 1 2)))
+(println (length (list 1 2 3 )))
+(println (length (list 1 2 3 4)))
+(println (length (list 1 2 3 4 5)))
+(println (length (list 1 2 3 4 5 6)))
+(println x)
+
+(println "Program time is over now!")

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -1,0 +1,622 @@
+;; A minimal lisp interpreter, meant to be compiled with slisp.
+;;
+;; Features:
+;;
+;;   Integer & floating-point numbers.
+;;   Strings.
+;;   Functions.
+;;   Lambdas (closures).
+;;
+;; We store built-in primitives, variables, and functions in different namespaces.
+;;
+;; Special forms:
+;;   IF
+;;   LAMBDA
+;;   LET
+;;   QUOTE
+;;   DEFUN
+;;   DEFVAR
+;;
+;; Nothing too surprising I guess.
+;;
+
+
+;; Since we don't "tag" things we wrap them in lists
+(defun builtin (name)
+  (list "builtin" name))
+
+(defun closure (params body env)
+  (list "closure" params body env))
+
+(defun symbol (name)
+  (list "symbol" name))
+
+
+;; now we need helpers to see if we have a given thing
+(defun builtin? (x)
+  (and (cons? x)
+       (= (car x) "builtin")))
+
+(defun closure? (x)
+  (and (cons? x)
+       (= (car x) "closure")))
+
+(defun symbol? (x)
+  (and
+   (cons? x)
+   (= (car x) "symbol")))
+
+
+;; And some type-specific helpers.
+(defun symbol-name (x)
+  (cadr x))
+
+(defun builtin-name (x)
+  (cadr x))
+
+(defun symbols-names (lst)
+  (if (nil? lst)
+      nil
+      (cons
+       (symbol-name (car lst))
+       (symbols-names (cdr lst)))))
+
+
+
+
+;; global storage for user-functions
+(defvar *functions*  nil)
+
+;; global storage for global variables
+(defvar *globals* nil)
+
+(defun global-get (name)
+  (env-get *globals* name))
+
+(defun global-set (name value)
+  (set! *globals* (env-set *globals* name value)))
+
+
+;; Lookup a builtin function.
+(defun lookup-builtin (name)
+  (cond
+    ((= name "+")       (builtin "+"))
+    ((= name "-")       (builtin "-"))
+    ((= name "*")       (builtin "*"))
+    ((= name "/")       (builtin "/"))
+    ((= name "<")       (builtin "<"))
+    ((= name "<=")      (builtin "<="))
+    ((= name ">")       (builtin ">"))
+    ((= name ">=")      (builtin ">="))
+    ((= name "cons")    (builtin "cons"))
+    ((= name "car")     (builtin "car"))
+    ((= name "cdr")     (builtin "cdr"))
+    ((= name "list")    (builtin "list"))
+    ((= name "print")   (builtin "print"))
+    ((= name "println") (builtin "println"))
+    ((= name "nil?")    (builtin "nil?"))
+    (t nil)))
+
+;; add a function
+(defun add-function (name params body)
+  (set! *functions*
+        (cons
+         (list
+          name
+          (closure params body nil))
+         *functions*))
+  name)
+
+;; get a function, by name
+(defun lookup-function (name)
+  (lookup-function-aux
+   name
+   *functions*))
+
+;; helper
+(defun lookup-function-aux (name functions)
+  (if (nil? functions)
+      nil
+      (if (= (car (car functions)) name)
+          (cadr (car functions))
+          (lookup-function-aux
+           name
+           (cdr functions)))))
+
+;; lookup a binding from the environment
+(defun env-get (env name)
+  (if (nil? env)
+      nil
+      (if (= (car (car env)) name)
+          (cadr (car env))
+          (env-get (cdr env) name))))
+
+
+;; set a variable in the environment
+(defun env-set (env name value)
+  (cons
+   (list name value)
+   env))
+
+
+;; eval: where the magic happens.
+(defun eval (expr env)
+  (cond
+    ;; integers evaluate to themselves
+    ((int? expr) expr)
+
+    ;; floats are self-evaluating too.
+    ((float? expr) expr)
+
+    ;; strings are self-evaluating too.
+    ((str? expr) expr)
+
+    ;; symbols will be looked up
+    ((symbol? expr) (eval-symbol expr env))
+
+    ;; lists are expressions
+    ((cons? expr) (eval-list expr env))
+
+    ;; something unknown
+    (t nil)))
+
+;; helper which is used by apply, do, and let.
+(defun eval-body (forms env)
+    (let ((result nil))
+        (while forms
+            (set! result (eval (car forms) env))
+            (set! forms (cdr forms)))
+        result))
+
+
+;; function-call, lambda, builtin, etc.
+(defun eval-call (expr env)
+  (let ((fn   (eval (car expr) env))
+        (args (map (lambda (x) (eval x env)) (cdr expr))))
+    (apply fn args)))
+
+;; special form: defun
+(defun eval-defun (expr)
+  (add-function
+   (symbol-name (cadr expr))
+   (symbols-names (caddr expr))
+   (cdddr expr))
+  ;; return the name of the defun
+  (cadr expr))
+
+;; special form: defvar - return the value
+(defun eval-defvar (expr env)
+  (let ((name  (symbol-name (cadr expr)))
+        (value (eval (caddr expr) env)))
+    (set! *globals* (env-set *globals* name value)) value))
+
+;; special form: do - run each statement in the list
+(defun eval-do (expr env)
+  (eval-body (cdr expr) env))
+
+;; special form; if
+(defun eval-if (expr env)
+  (if (eval (cadr expr) env)
+      (eval (caddr expr) env)
+      (eval (cadddr expr) env)))
+
+;; evaluate a lambda
+(defun eval-lambda (expr env)
+    (closure
+        (symbols-names (cadr expr))
+        (cddr expr)
+        env))
+
+;; special form: let
+(defun eval-let (expr env)
+  (let ((bindings (cadr expr))
+        (body     (cddr expr))
+        (new-env  env))
+    (while bindings
+      (set! new-env
+            (env-set
+             new-env
+             (symbol-name (car (car bindings)))
+             (eval (cadr (car bindings))
+                   env)))
+      (set! bindings (cdr bindings)))
+    (eval-body body new-env)))
+
+
+;; evaluate a list - sleazy
+(defun eval-list (expr env)
+  (let ((op (symbol-name (car expr))))
+    (cond
+      ((= op "defun")
+       (eval-defun expr))
+      ((= op "defvar")
+       (eval-defvar expr env))
+      ((= op "do")
+       (eval-do expr env))
+      ((= op "if")
+       (eval-if expr env))
+      ((= op "lambda")
+       (eval-lambda expr env))
+      ((= op "let")
+       (eval-let expr env))
+      ((= op "quote")
+       (eval-quote expr env))
+      (t
+       (eval-call expr env)))))
+
+;; return the contents of a symbol
+(defun eval-symbol (sym env)
+  (let ((name (symbol-name sym)))
+    ;; environment
+    (let ((value (env-get env name)))
+      (if value
+          value
+
+          ;; global variable
+          (let ((value (env-get *globals* name)))
+            (if value
+                value
+
+                ;; builtin
+                (let ((fn (lookup-builtin name)))
+                  (if fn
+                      fn
+                      ;; user-function
+                      (lookup-function name)))))))))
+
+;; special form: quote
+(defun eval-quote (expr env)
+  (cadr expr))
+
+
+;; apply for built-in and user-functoins
+(defun apply (fn args)
+  (cond
+    ;; native builtins
+    ((builtin? fn) (apply-builtin fn args))
+
+    ;; user functions and lambdas
+    ((closure? fn) (apply-closure fn args))
+
+    ;; nothing known
+    (t nil)))
+
+;; built-in functions all live here, which is a bit horrid.
+(defun apply-builtin (fn args)
+  (let ((name (builtin-name fn)))
+    (cond
+      ((= name "+")
+       (+ (car args) (cadr args)))
+
+      ((= name "-")
+       (- (car args) (cadr args)))
+
+      ((= name "*")
+       (* (car args) (cadr args)))
+
+      ((= name "/")
+       (/ (car args) (cadr args)))
+
+      ((= name "<")
+       (< (car args) (cadr args)))
+
+      ((= name "<=")
+       (<= (car args) (cadr args)))
+
+      ((= name ">")
+       (> (car args) (cadr args)))
+
+      ((= name ">=")
+       (>= (car args) (cadr args)))
+
+      ((= name "cons")
+       (cons (car args) (cadr args)))
+
+      ((= name "car")
+       (car (car args)))
+
+      ((= name "cdr")
+       (cdr (car args)))
+
+      ((= name "list")
+       args)
+
+      ((= name "print")
+       (do
+        (while args
+          (print (car args))
+          (set! args (cdr args)))
+        nil))
+
+      ((= name "println")
+       (do
+        (while args
+          (print (car args))
+          (set! args (cdr args)))
+        (print "\n")
+        nil))
+
+      ((= name "nil?")
+       (nil? (car args)))
+
+      (t
+       nil))))
+
+
+(defun apply-closure (closure args)
+  (let ((params (cadr closure))
+        (body   (caddr closure))
+        (env    (cadddr closure)))
+
+    ;; extend the captured environment
+    (while params
+      (set! env
+            (env-set
+             env
+             (car params)
+             (car args)))
+
+      (set! params (cdr params))
+      (set! args   (cdr args)))
+
+    ;; Now execute all the statements in the body
+    (eval-body body env)))
+
+
+;;
+;; Reader
+;;
+(defvar *reader-text* "")
+(defvar *reader-pos* 0)
+
+(defun reader-init (text)
+  (set! *reader-text* text)
+  (set! *reader-pos* 0))
+
+(defun reader-eof ()
+  (>= *reader-pos*
+      (strlen *reader-text*)))
+
+(defun reader-peek ()
+  (if (reader-eof)
+      ""
+      (substr
+       *reader-text*
+       *reader-pos*
+       1)))
+
+(defun reader-next ()
+  (let ((ch (reader-peek)))
+    (set! *reader-pos* (+ *reader-pos* 1))
+    ch))
+
+
+;; Is the given value a number component "-", ".", and "0-9"
+(defun numeric-char? (ch)
+  (or
+   (= ch "-")
+   (= ch ".")
+   (= ch "0")
+   (= ch "1")
+   (= ch "2")
+   (= ch "3")
+   (= ch "4")
+   (= ch "5")
+   (= ch "6")
+   (= ch "7")
+   (= ch "8")
+   (= ch "9")))
+
+;; Is the given string 100% numeric-plausible?
+(defun number-string? (s)
+  (cond
+    ((= s "") nil)
+    ((= (substr s 0 1) "-")
+     (and
+      (> (strlen s) 1)
+      (number-string-aux s 1)))
+    (t
+     (number-string-aux s 0))))
+
+;; helper
+(defun number-string-aux (s pos)
+  (if (>= pos (strlen s))
+      t
+      (if (numeric-char?
+           (substr s pos 1))
+          (number-string-aux
+           s
+           (+ pos 1))
+          nil)))
+
+
+;; skip over whitespace and comments
+(defun reader-skip ()
+  (let ((again t))
+    (while again
+      (set! again nil)
+
+      ;; Skip whitespace
+      (while
+          (or
+           (= (reader-peek) " ")
+           (= (reader-peek) "\t")
+           (= (reader-peek) "\n")
+           (= (reader-peek) "\r"))
+        (reader-next))
+
+      ;; Skip a comment
+      (if (= (reader-peek) ";")
+          (let ()
+            (reader-skip-comment)
+            (set! again t))))))
+
+(defun reader-read ()
+  (reader-skip)
+  (cond
+    ((= (reader-peek) "(")
+     (reader-read-list))
+    ((= (reader-peek) ")")
+     (do
+      (println "unexpected ')' character.  Aborting")
+      (exit 1)))
+    ((= (reader-peek) "\"")
+     (reader-read-string))
+    ((= (reader-peek) "'")
+     (reader-next)
+     (list
+      "quote"
+      (reader-read)))
+    (t
+     (reader-read-atom))))
+
+(defun reader-skip-comment ()
+  ;; consume the ';'
+  (reader-next)
+
+  ;; skip until newline or EOF
+  (while
+      (and
+       (!= (reader-peek) "")
+       (!= (reader-peek) "\n"))
+    (reader-next))
+  ;; consume the newline if present
+  (if (= (reader-peek) "\n")
+      (reader-next)))
+
+(defun reader-read-list ()
+  ;; consume '('
+  (reader-next)
+  (let ((items nil))
+    (reader-skip)
+    (while (!= (reader-peek) ")")
+      (set! items
+            (cons
+             (reader-read)
+             items))
+      (reader-skip))
+    ;; consume ')'
+    (reader-next)
+    (reverse items)))
+
+(defun reader-read-string ()
+  ;; consume opening "
+  (reader-next)
+  (let ((text ""))
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) "\""))
+      (set! text
+            (strcat
+             text
+             (reader-next))))
+
+    ;; consume closing "
+    (if (= (reader-peek) "\"")
+        (reader-next))
+    text))
+
+(defun reader-read-atom ()
+  (let ((token ""))
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) " ")
+         (!= (reader-peek) "\t")
+         (!= (reader-peek) "\r")
+         (!= (reader-peek) "\n")
+         (!= (reader-peek) "(")
+         (!= (reader-peek) ")"))
+
+      (set! token
+            (strcat
+             token
+             (reader-next))))
+
+    ;; Is this a number?
+    (if (number-string? token)
+        (atof token)
+        (symbol token))))
+
+
+;; parse a complete program and return all the expressions within it.
+(defun reader-parse-program ()
+  (let ((forms nil))
+    (reader-skip)
+    (while (not (reader-eof))
+      (set! forms
+            (cons
+             (reader-read)
+             forms))
+      (reader-skip))
+    (reverse forms)
+    ))
+
+;; given a list of expressions, evaluate them all
+(defun eval-program (forms)
+  (let ((result nil))
+    (while forms
+      (set! result (eval (car forms) nil))
+      (set! forms  (cdr forms)))
+    result))
+
+;; Evaluate a program comprised of expressions
+(defun run-program (text)
+  (reader-init text)
+  (eval-program (reader-parse-program)))
+
+
+;; REPL code
+(defun repl ()
+  (println "Welcome to lisp in slisp!")
+  (println "Enter :quit to exit.")
+  (println "")
+
+  (let ((run t))
+    (while run
+      (print "> ")
+      (let ((line (read-line)))
+        (if (= line ":quit")
+            (set! run nil)
+            (let ((result
+                   (repl-execute-line line)))
+              (if result
+                  (println result))))))))
+
+(defun repl-execute-line (text)
+  (reader-init text)
+  (eval-program (reader-parse-program)))
+
+
+;;
+;; Entry point.
+;;
+(defun main (args)
+  "Entry-Point, either start the REPL or process each named file."
+
+  ;; no args?  show error and terminate
+  (if (= (length args) 1 )
+      (do
+       (println "Usage " (car args) " --repl | path/to/run")
+       (exit 1)))
+
+  ;; We process each named file (skipping --repl)
+  (map (lambda (name)
+         (if (!= name "--repl")
+             (do
+              (println "Loading .. " name)
+              (let ((handle (fopen name "r"))  ; open
+                    (data   (fread handle))    ; read
+                    (res    (fclose handle)))  ; close
+                (if data
+                    (run-program data))))))
+         (cdr args))
+
+
+  ;; Is this REPL mode?  Then run it
+  (if (member? args "--repl")
+      (do
+       (repl)
+       (exit 0)))
+)

--- a/examples/inception.test.expected
+++ b/examples/inception.test.expected
@@ -1,0 +1,1 @@
+Usage ./inception.test --repl | path/to/run

--- a/examples/inception.test.expected
+++ b/examples/inception.test.expected
@@ -1,1 +1,28 @@
-Usage ./inception.test --repl | path/to/run
+Loading .. inception.in
+100
+Squaring some numbers: (16 25 400 900 1600)
+LAMBDA X 1*1: -> 1
+LAMBDA X 2*2: -> 4
+LAMBDA X 3*3: -> 9
+LAMBDA X 4*4: -> 16
+LAMBDA X 5*5: -> 25
+This is what a function looks like: (closure (x) (((symbol +) (symbol x) (symbol n))) ((n 10)))
+Adder (+10) result for  5:15
+Adder (+10) result for 25:35
+Some maths:
+  330
+  962
+  3
+  0.100000
+-2
+-1
+<nil>
+0
+1
+2
+3
+4
+5
+6
+7
+Program time is over now!

--- a/test/closure1.lisp
+++ b/test/closure1.lisp
@@ -2,9 +2,8 @@
   "Counter returns a function which will return an incrementing number every time it is called."
   (let ((n 0))
     (lambda ()
-      (do
-        (set! n (+ n 1))
-        n))))
+      (set! n (+ n 1))
+      n)))
 
 (defun main()
   (let ((f (counter)))


### PR DESCRIPTION
Once complete this will close #170 by implementing a lisp interpreter within our own language:

* Compile inception.lisp -> inception
* Then run programs which are /interpreted/ using it.

We support string/int/float/symbol/defun/lambda and the only real issue with it is that the standard-library is mostly absent.