### PR TITLE
Inception; nqueens

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ The compiler prepends [stdlib.slisp](stdlib.slisp) to all programs, so you alway
 
 That said, and as demonstrated above, the interpreter can run many of the same programs that the compiler can.  The main omissions are mutating captured variables inside closures, and the need to enter functions all on one line if you're using the REPL.
 
+* [examples/inception.in](examples/inception.in) is my test program.
+* [examples/cond.in](examples/cond.in) shows that the in-build `cond` primitive works.
+
 
 
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -213,13 +213,39 @@ Loading .. ../test/closure2.lisp
 Welcome to lisp in slisp!
 Enter :quit to exit.
 
-> (main)   ; loading "closure2.lisp" will produce a (defun main) now we call it.
+; loading "closure2.lisp" will produce a (defun main) now we call it.
+> (main)
 25
 35
 5
 10
 22
 40
+```
+
+Perhaps more interesting is that we can execute the [examples/nqueens.lisp](examples/nqueens.lisp) example, with no changes:
+
+```
+$ ./inception nqueens.lisp  --repl
+Loading .. nqueens.lisp
+Welcome to lisp in slisp!
+Enter :quit to exit.
+
+> (main)
+8 Queens Solver for board size 8x8
+
+Solution 1 (1 5 8 6 3 7 2 4):
+
+    Q . . . . . . .
+    . . . . Q . . .
+    . . . . . . . Q
+    . . . . . Q . .
+    . . Q . . . . .
+    . . . . . . Q .
+    . Q . . . . . .
+    . . . Q . . . .
+
+..
 ```
 
 So what are the differences between our _compiler_ and our _interpreter_?  Well in some ways the interpreter is more advanced as it has support for `(quote)`, it has a symbol-type, and you can get references to functions using them.  The lambdas/defuns are real standalone objects which are treated largely interchangeably and which you can print.  But the biggest difference is that the compiler has a significantly larger standard-library.

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -2356,6 +2356,7 @@ dir_buffer_end:
 ;; heap storage
 heap:
     resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
 
 
 

--- a/examples/cond.in
+++ b/examples/cond.in
@@ -1,0 +1,31 @@
+;; map
+(defun map (f xs)
+    (if (nil? xs)
+        nil
+        (cons
+            (f (car xs))
+            (map f (cdr xs)))))
+
+
+;; odd/even helpers
+(defun odd? (x)
+  (if (= (% x 2)  1)
+     1
+    nil))
+
+(defun even? (x)
+  (if (= (% x 2)  0)
+     1
+    nil))
+
+;; function to show results, via cond
+(defun show (x)
+  (cond
+    ((odd? x) (println "odd: " x))
+    ((even? x) (println "even: " x))
+    (t (println "Meh - life is hard"))
+    )
+)
+
+;; Show the results of the first 20 numbers.
+(map show (nat 20))

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -75,7 +75,11 @@
   (env-get *globals* name))
 
 (defun global-set (name value)
-  (set! *globals* (env-set *globals* name value)))
+  (if (env-bound? *globals* name)
+      (set! *globals*
+            (env-update *globals* name value))
+      (set! *globals*
+            (env-set *globals* name value))))
 
 
 ;; Lookup a builtin function.
@@ -97,9 +101,12 @@
     ((= name "cdr")     (builtin "cdr"))
     ((= name "list")    (builtin "list"))
     ((= name "nat")     (builtin "nat"))
+    ((= name "newline") (builtin "newline"))
     ((= name "not")     (builtin "not"))
+    ((= name "or")      (builtin "or"))
     ((= name "print")   (builtin "print"))
     ((= name "println") (builtin "println"))
+    ((= name "reverse") (builtin "reverse"))
     ((= name "seq")     (builtin "seq"))
     ((= name "nil?")    (builtin "nil?"))
     (t nil)))
@@ -138,6 +145,19 @@
           (cadr (car env))
           (env-get (cdr env) name))))
 
+;; is a binding present?
+(defun env-bound? (env name)
+  (cond
+    ((nil? env)
+     nil)
+
+    ((= (caar env) name)
+     t)
+
+    (t
+     (env-bound?
+       (cdr env)
+       name))))
 
 ;; set a variable in the environment
 (defun env-set (env name value)
@@ -145,73 +165,141 @@
    (list name value)
    env))
 
+(defun env-update (env name value)
+  (cond
+    ((nil? env)
+     nil)
+    ((= (caar env) name)
+     (cons
+      (list name value)
+      (cdr env)))
+    (t
+     (cons
+      (car env)
+      (env-update
+       (cdr env)
+       name
+       value)))))
+
+;; eval will return a list: (return-value updated-environment)
+;; get the value.
+(defun eval-value (x)
+  (car x))
+
+;; eval will return a list: (return-value updated-environment)
+;; get the environment
+(defun eval-env (x)
+  (cadr x))
 
 ;; eval: where the magic happens.
 (defun eval (expr env)
   (cond
     ;; integers evaluate to themselves
-    ((int? expr) expr)
+    ((int? expr) (list expr env))
 
     ;; floats are self-evaluating too.
-    ((float? expr) expr)
+    ((float? expr) (list expr env))
 
     ;; strings are self-evaluating too.
-    ((str? expr) expr)
+    ((str? expr) (list expr env))
 
     ;; symbols will be looked up
-    ((symbol? expr) (eval-symbol expr env))
+    ((symbol? expr) (list (eval-symbol expr env) env))
 
     ;; lists are expressions
     ((cons? expr) (eval-list expr env))
 
     ;; something unknown
-    (t nil)))
+    (t (list nil env))))
 
 ;; helper which is used by apply, do, and let.
 (defun eval-body (forms env)
-    (let ((result nil))
-        (while forms
-            (set! result (eval (car forms) env))
-            (set! forms (cdr forms)))
-        result))
+  (let ((result nil))
+    (while forms
+      (set! result (eval (car forms) env))
+      (set! env (eval-env result))
+      (set! forms (cdr forms)))
+    result))
 
 
 ;; function-call, lambda, builtin, etc.
 (defun eval-call (expr env)
-  (let ((fn   (eval (car expr) env))
-        (args (map (lambda (x) (eval x env)) (cdr expr))))
-    (apply fn args)))
+  (let ((fn-result
+         (eval (car expr) env)))
+
+    (let ((fn
+           (car fn-result))
+          (env
+           (cadr fn-result))
+          (args nil)
+          (forms
+           (cdr expr)))
+
+      ;; evaluate arguments left-to-right
+      (while forms
+
+        (let ((result
+               (eval (car forms) env)))
+          (set! args
+                (append
+                 args
+                 (list (car result))))
+          (set! env
+                (cadr result)))
+        (set! forms
+              (cdr forms)))
+      (list
+       (apply fn args)
+       env))))
 
 ;; special form: cond
 (defun eval-cond (expr env)
-    (eval-cond-clauses (cdr expr) env))
+  (eval-cond-clauses (cdr expr) env))
 
 (defun eval-cond-clauses (clauses env)
-    (if (nil? clauses)
-        nil
-        (let ((clause (car clauses)))
-            (if (or
-                    (= (car clause) t)
-                    (eval (car clause) env))
-                (eval-body (cdr clause) env)
-                (eval-cond-clauses
-                    (cdr clauses)
-                    env)))))
+  (if (nil? clauses)
+      (list nil env)
+
+      (let ((clause (car clauses)))
+
+        ;; Evaluate the test expression.
+        (let ((result (eval (car clause) env)))
+
+          (if (eval-value result)
+
+              ;; Test succeeded.
+              (eval-body
+               (cdr clause)
+               (eval-env result))
+
+              ;; Try the next clause.
+              (eval-cond-clauses
+               (cdr clauses)
+               (eval-env result)))))))
 
 ;; special form: defun
-(defun eval-defun (expr)
+(defun eval-defun (expr env)
   (add-function
    (symbol-name (cadr expr))    ; name
    (symbols-names (caddr expr)) ; params
    (cdddr expr))                ; body
   ;; return the name of the defun
-  (cadr expr))
+  (list (cadr expr)  env))
 
 ;; special form: defvar - return the value
 (defun eval-defvar (expr env)
-  (let ((name  (symbol-name (cadr expr)))
-        (value (eval (caddr expr) env)))
-    (set! *globals* (env-set *globals* name value)) value))
+  (let ((name (symbol-name (cadr expr)))
+        (result (eval (caddr expr) env)))
+
+    (set! *globals*
+          (env-set
+           *globals*
+           name
+           (eval-value result)))
+
+    (list
+     (eval-value result)
+     (eval-env result))))
 
 ;; special form: do - run each statement in the list
 (defun eval-do (expr env)
@@ -219,32 +307,37 @@
 
 ;; special form; if
 (defun eval-if (expr env)
-  (if (eval (cadr expr) env)
-      (eval (caddr expr) env)
-      (eval (cadddr expr) env)))
+  (let ((r (eval (cadr expr) env)))
+    (if (eval-value r)
+        (eval (caddr expr) (eval-env r))
+        (eval (cadddr expr) (eval-env r)))))
 
 ;; evaluate a lambda
 (defun eval-lambda (expr env)
-    (closure
-        (symbols-names (cadr expr)) ; params
-        (cddr expr)                 ; body
-        env))
+  (list
+   (closure
+    (symbols-names (cadr expr)) ; params
+    (cddr expr)                 ; body
+    env)
+   env))
 
 ;; special form: let
 (defun eval-let (expr env)
   (let ((bindings (cadr expr))
         (body     (cddr expr))
         (new-env  env))
+
     (while bindings
-      (set! new-env
-            (env-set
-             new-env
-             (symbol-name (car (car bindings)))
+      (let ((result
              (eval (cadr (car bindings))
-                   env)))
+                   new-env)))
+        (set! new-env
+              (env-set
+               new-env
+               (symbol-name (car (car bindings)))
+               (eval-value result))))
       (set! bindings (cdr bindings)))
     (eval-body body new-env)))
-
 
 ;; evaluate a list - sleazy
 (defun eval-list (expr env)
@@ -253,7 +346,7 @@
       ((= op "cond")
        (eval-cond expr env))
       ((= op "defun")
-       (eval-defun expr))
+       (eval-defun expr env))
       ((= op "defvar")
        (eval-defvar expr env))
       ((= op "do")
@@ -266,8 +359,30 @@
        (eval-let expr env))
       ((= op "quote")
        (eval-quote expr env))
+      ((= op "set!")
+       (eval-set expr env))
       (t
        (eval-call expr env)))))
+
+;; eval set!
+(defun eval-set (expr env)
+ (let ((name
+         (symbol-name (cadr expr))))
+
+    (let ((result
+           (eval (caddr expr) env)))
+
+      (let ((value
+             (car result))
+            (env
+             (cadr result)))
+
+        (if (env-bound? env name)
+    (list value
+          (env-update env name value))
+    (do
+      (global-set name value)
+      (list value env)))))))
 
 ;; return the contents of a symbol
 (defun eval-symbol (sym env)
@@ -282,26 +397,27 @@
        nil)
 
       (t
-    ;; environment
-    (let ((value (env-get env name)))
-      (if value
-          value
 
-          ;; global variable
-          (let ((value (env-get *globals* name)))
-            (if value
-                value
+       ;; env
+       (if (env-bound? env name)
+           (env-get env name)
 
-                ;; builtin
-                (let ((fn (lookup-builtin name)))
-                  (if fn
-                      fn
-                      ;; user-function
-                      (lookup-function name)))))))))))
+           ;; global
+           (if (env-bound? *globals* name)
+               (env-get *globals* name)
+
+               ;; builtin
+               (let ((fn (lookup-builtin name)))
+                 (if fn
+                     fn
+                     ;; user-function
+                     (lookup-function name)))))))))
 
 ;; special form: quote
 (defun eval-quote (expr env)
-  (cadr expr))
+  (list
+   (cadr expr)
+   env))
 
 
 ;; apply for built-in and user-functoins
@@ -368,8 +484,17 @@
       ((= name "nat")
        (nat (car args)))
 
+      ((= name "newline")
+       (newline))
+
       ((= name "not")
        (not (car args)))
+
+      ((= name "or")
+       (or (car args) (cadr args)))
+
+      ((= name "reverse")
+       (reverse (car args)))
 
       ((= name "print")
        (do
@@ -413,7 +538,7 @@
       (set! args   (cdr args)))
 
     ;; Now execute all the statements in the body
-    (eval-body body env)))
+    (car (eval-body body env))))
 
 
 ;;
@@ -518,7 +643,7 @@
     ((= (reader-peek) "'")
      (reader-next)
      (list
-      "quote"
+      (symbol "quote")
       (reader-read)))
     (t
      (reader-read-atom))))
@@ -553,6 +678,38 @@
     (reverse items)))
 
 (defun reader-read-string ()
+  (reader-next)   ; consume opening "
+
+  (let ((text ""))
+
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) "\""))
+
+      (if (= (reader-peek) "\\")
+          (do
+            (reader-next)     ; consume '\'
+
+            (let ((ch (reader-next)))
+              (set! text
+                    (strcat
+                     text
+                     (cond
+                       ((= ch "n") "\n")
+                       ((= ch "t") "\t")
+                       ((= ch "\"") "\"")
+                       ((= ch "\\") "\\")
+                       (t ch))))))
+          (set! text
+                (strcat
+                 text
+                 (reader-next)))))
+
+    (reader-next)    ; closing "
+    text))
+
+(defun reader-read-string-old ()
   ;; consume opening "
   (reader-next)
   (let ((text ""))
@@ -664,7 +821,7 @@
                     (res    (fclose handle)))  ; close
                 (if data
                     (run-program data))))))
-         (cdr args))
+       (cdr args))
 
 
   ;; Is this REPL mode?  Then run it
@@ -672,4 +829,4 @@
       (do
        (repl)
        (exit 0)))
-)
+  )

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -182,6 +182,22 @@
         (args (map (lambda (x) (eval x env)) (cdr expr))))
     (apply fn args)))
 
+;; special form: cond
+(defun eval-cond (expr env)
+    (eval-cond-clauses (cdr expr) env))
+
+(defun eval-cond-clauses (clauses env)
+    (if (nil? clauses)
+        nil
+        (let ((clause (car clauses)))
+            (if (or
+                    (= (car clause) t)
+                    (eval (car clause) env))
+                (eval-body (cdr clause) env)
+                (eval-cond-clauses
+                    (cdr clauses)
+                    env)))))
+
 ;; special form: defun
 (defun eval-defun (expr)
   (add-function
@@ -234,6 +250,8 @@
 (defun eval-list (expr env)
   (let ((op (symbol-name (car expr))))
     (cond
+      ((= op "cond")
+       (eval-cond expr env))
       ((= op "defun")
        (eval-defun expr))
       ((= op "defvar")
@@ -254,6 +272,16 @@
 ;; return the contents of a symbol
 (defun eval-symbol (sym env)
   (let ((name (symbol-name sym)))
+
+    ;; boolean constants
+    (cond
+      ((= name "t")
+       t)
+
+      ((= name "nil")
+       nil)
+
+      (t
     ;; environment
     (let ((value (env-get env name)))
       (if value
@@ -269,7 +297,7 @@
                   (if fn
                       fn
                       ;; user-function
-                      (lookup-function name)))))))))
+                      (lookup-function name)))))))))))
 
 ;; special form: quote
 (defun eval-quote (expr env)

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -156,8 +156,8 @@
 
     (t
      (env-bound?
-       (cdr env)
-       name))))
+      (cdr env)
+      name))))
 
 ;; set a variable in the environment
 (defun env-set (env name value)
@@ -366,7 +366,7 @@
 
 ;; eval set!
 (defun eval-set (expr env)
- (let ((name
+  (let ((name
          (symbol-name (cadr expr))))
 
     (let ((result
@@ -378,11 +378,11 @@
              (cadr result)))
 
         (if (env-bound? env name)
-    (list value
-          (env-update env name value))
-    (do
-      (global-set name value)
-      (list value env)))))))
+            (list value
+                  (env-update env name value))
+            (do
+             (global-set name value)
+             (list value env)))))))
 
 ;; return the contents of a symbol
 (defun eval-symbol (sym env)
@@ -689,18 +689,18 @@
 
       (if (= (reader-peek) "\\")
           (do
-            (reader-next)     ; consume '\'
+           (reader-next)     ; consume '\'
 
-            (let ((ch (reader-next)))
-              (set! text
-                    (strcat
-                     text
-                     (cond
-                       ((= ch "n") "\n")
-                       ((= ch "t") "\t")
-                       ((= ch "\"") "\"")
-                       ((= ch "\\") "\\")
-                       (t ch))))))
+           (let ((ch (reader-next)))
+             (set! text
+                   (strcat
+                    text
+                    (cond
+                      ((= ch "n") "\n")
+                      ((= ch "t") "\t")
+                      ((= ch "\"") "\"")
+                      ((= ch "\\") "\\")
+                      (t ch))))))
           (set! text
                 (strcat
                  text


### PR DESCRIPTION
This pull-request updates our lisp _interpreter_, inception, to successfully execute the `nqueens.lisp` example program.

This required three main changes:

* Bump the heap-size.
* Expose `or` to the runtime, `newline`, and `reverse`.
* Update our string reader to convert `\n` into a newline, etc.
* Update to handle `set!` better.
  *  Now our forms, generally, return "(result env)" and we update the environment all the time using that.

There were other minor changes, but those were the main ones.