### PR TITLE
Allow auto-running the `(defun main ..` from inception

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ Loading .. ../test/closure2.lisp
 Welcome to lisp in slisp!
 Enter :quit to exit.
 
-; loading "closure2.lisp" will produce a (defun main) now we call it.
+; loading "closure2.lisp" will define (defun main)
+; now we call it via the REPL:
 > (main)
 25
 35
@@ -226,12 +227,9 @@ Enter :quit to exit.
 Perhaps more interesting is that we can execute the [examples/nqueens.lisp](examples/nqueens.lisp) example, with no changes:
 
 ```
-$ ./inception nqueens.lisp  --repl
+$ ./inception nqueens.lisp  --main
 Loading .. nqueens.lisp
-Welcome to lisp in slisp!
-Enter :quit to exit.
 
-> (main)
 8 Queens Solver for board size 8x8
 
 Solution 1 (1 5 8 6 3 7 2 4):
@@ -239,14 +237,11 @@ Solution 1 (1 5 8 6 3 7 2 4):
     Q . . . . . . .
     . . . . Q . . .
     . . . . . . . Q
-    . . . . . Q . .
-    . . Q . . . . .
-    . . . . . . Q .
-    . Q . . . . . .
-    . . . Q . . . .
-
+..
 ..
 ```
+
+> Here you'll see we added `--main` which automatically runs the `(main)` function our examples define.
 
 So what are the differences between our _compiler_ and our _interpreter_?  Well in some ways the interpreter is more advanced as it has support for `(quote)`, it has a symbol-type, and you can get references to functions using them.  The lambdas/defuns are real standalone objects which are treated largely interchangeably and which you can print.  But the biggest difference is that the compiler has a significantly larger standard-library.
 

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -349,6 +349,8 @@
        (eval-defun expr env))
       ((= op "defvar")
        (eval-defvar expr env))
+      ((= op "defconst")
+       (eval-defvar expr env))
       ((= op "do")
        (eval-do expr env))
       ((= op "if")
@@ -813,7 +815,8 @@
 
   ;; We process each named file (skipping --repl)
   (map (lambda (name)
-         (if (!= name "--repl")
+         (if (and (!= name "--repl")
+                  (!= name "--main"))
              (do
               (println "Loading .. " name)
               (let ((handle (fopen name "r"))  ; open
@@ -823,6 +826,9 @@
                     (run-program data))))))
        (cdr args))
 
+  ;; Should we auto-run (defun main) ..?
+  (if (member? args "--main")
+      (repl-execute-line "(main)"))
 
   ;; Is this REPL mode?  Then run it
   (if (member? args "--repl")


### PR DESCRIPTION
This simplifies running the examples.

Also define `defconst` as equivilent to `defvar`, which allows `globals.lisp` to be interpreted correctly.