### PR TITLE
Attempt to detect heap exhaustion.

### DIFF
--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -948,6 +948,11 @@ FUNC fn_chr
 ;; 16-bytes; first has the CAR, second the CDR.
 FUNC fn_cons
     mov rax, [heap_ptr]      ; get the value of the heap pointer
+    push rbx
+    mov rbx, heap_end        ; we allocate 8Mb. but we abort if we go past 7Mb.
+    cmp rax, rbx
+    pop rbx
+    jge heap_exhausted       ; then abort
     add qword [heap_ptr], 16 ; bump it by 2x ptrs
     mov [rax], rdi           ; store first item
     mov [rax+8], rsi         ; second item
@@ -2241,6 +2246,19 @@ out_of_range:
     jmp fn_exit
 
 
+section .text.heap_error,"ax",@progbits
+
+heap_exhausted:
+    mov rdi, heap_error_msg              ; show the error
+    TAG_STRING_REG rdi
+    call fn_printstr
+    mov rdi, qword [rel last_function]   ; and the function-name
+    TAG_STRING_REG rdi
+    call fn_printstr
+    call fn_newline
+    mov rdi, 1                           ; exit-code
+    jmp fn_exit
+
 section .text.type_error,"ax",@progbits
 
 type_error:
@@ -2273,6 +2291,12 @@ nil_str:
 align 8
 out_of_range_msg:
         db `Out of bounds access.  Aborted inside `
+        db 00
+
+;; error message for heap exhaustion
+align 8
+heap_error_msg:
+        db `Heap exhausted! Aborted inside `
         db 00
 
 ;; error message for type-errors
@@ -2356,6 +2380,13 @@ dir_buffer_end:
 ;; heap storage
 heap:
     resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+    resb 1 * 1024 * 1024 * 1024  ; 1 Mb
+heap_end:
     resb 1 * 1024 * 1024 * 1024  ; 1 Mb
 
 

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -239,6 +239,11 @@ _start:
 ;; xmm0 contains a float, store it on the heap and return it
 return_float:
    mov rax, [heap_ptr]     ; allocate
+    push rbx
+    mov rbx, heap_end        ; we allocate 8Mb. but we abort if we go past 7Mb.
+    cmp rax, rbx
+    pop rbx
+    jge heap_exhausted       ; then abort
    add qword [heap_ptr],8
    movq [rax], xmm0        ; store
    TAG_FLOAT_REG rax       ; type


### PR DESCRIPTION
Since this is a common cause of segfaults this pull-request updates our heap:

* We now allocate 8Mb.
* But if more than 7Mb is used
  * We detect that and abort cleanly.

We don't check this everywhere, just in fn_cons / `(cons ..)` and our float-returning maths-code.  So far the heap exhaustion cases have only been those that use deep recursion and list-primitives so this is probably good enough to catch that.

This is a best-effort attempt anyway, so if it isn't perfect that's okay.

The increase in size allows the `nqueens` example to complete all solutions for 12x12 boards, which is nice.