### PR TITLE
Provide `when` as a special form

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ It should be noted that we prepend a standard library of functions to all user p
   * `(require ..)` - `*` - Include other source files.
   * `(package ..)` - `*` - Declare a package-scope.
   * `(set! ..)`
+  * `(when ..)`
   * `(while ..)`
 
 You can see a complete list of our primitives, and their details in [PRIMITIVES.md](PRIMITIVES.md) - documenting both the built-in special-forms, and the parts of the standard library which are implemented in assembly, or `slisp` itself.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1140,6 +1140,28 @@ func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 
 		return fmt.Errorf("unknown variable: %s [package '%s']", n.Name, c.inPackage)
 
+	case *parser.When:
+		endLbl := c.label("endwhen")
+
+		err := c.emitExpr(n.Cond, ev)
+		if err != nil {
+			return err
+		}
+
+		c.emitln("    GET_TAG_BITS rax     ; get type bits")
+		c.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
+		c.emitln("    jz " + endLbl)
+
+		// assemble the body
+		for _, expr := range n.Exprs {
+			err := c.emitExpr(expr, ev)
+			if err != nil {
+				return err
+			}
+		}
+
+		c.emitln(endLbl + ":")
+
 	case *parser.While:
 
 		// create label for now, and the end

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -23,6 +23,7 @@
 ;;   OR
 ;;   QUOTE
 ;;   SET!
+;;   WHEN
 ;;   WHILE
 ;;
 ;; We have a couple of builtin-functions we handle specially, but most are deferred to the
@@ -407,6 +408,8 @@
        (eval-quote expr env))
       ((= op "set!")
        (eval-set expr env))
+      ((= op "when")
+       (eval-when expr env))
       ((= op "while")
        (eval-while expr env))
       (t
@@ -488,6 +491,12 @@
   (list
    (cadr expr)
    env))
+
+;; special form: while
+(defun eval-when (expr env)
+  (let ((r (eval (cadr expr) env)))
+    (if (eval-value r)
+        (eval-body (cdr expr) env))))
 
 ;; special form: while
 (defun eval-while (expr env)

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -164,6 +164,11 @@ type Set struct {
 	Expr Expr
 }
 
+type When struct {
+	Cond  Expr
+	Exprs []Expr
+}
+
 type While struct {
 	Cond  Expr
 	Exprs []Expr

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -595,6 +595,30 @@ func (p *Parser) parseList() (Expr, error) {
 				Expr: expr,
 			}, nil
 
+		case "when":
+			cond, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+
+			var exprs []Expr
+
+			for p.peek() != ")" && p.peek() != "" {
+				x, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				exprs = append(exprs, x)
+			}
+
+			if !p.expectNext(")") {
+				return nil, fmt.Errorf("expected ')' after while-expressions")
+			}
+
+			return &When{Cond: cond,
+				Exprs: exprs,
+			}, nil
+
 		case "while":
 			cond, err := p.parseExpr()
 			if err != nil {


### PR DESCRIPTION
This pull-request updates our compiler to understand the `when` special form, which might be used like this:

    (when (< i 10)
       (println "I'm low")
       (println "and there are multiple expressions here"))

A good companion to `if`.

This closes #186.