### PR TITLE
Implement special form for `unless`

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -94,6 +94,24 @@ If you want to run multiple expressions in either the "true" or "false" branch u
         (print "Multiple expressions can happen here..")
         ))
 
+As noted you can use `do` to execute multiple blocks, but a simpler alternative is to use `when` and `unless`.  These are conditionals which allow running a block of code when a condition is true, or false.  The difference here is that you cannot have both a TRUE and FALSE block at the same time, only one or the other:
+
+    ; When the condition is true, run the expressions.
+    (when (< i 10)
+      (println "This is an expression")
+      (println "This is an expression")
+      (println "This is an expression")
+      )
+
+    ; When the condition is false, run the expressions.
+    (unless nil
+      (println "This is an expression")
+      (println "This is an expression")
+      (println "This is an expression")
+      )
+
+There
+
 
 
 ## Functions

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ It should be noted that we prepend a standard library of functions to all user p
   * `(require ..)` - `*` - Include other source files.
   * `(package ..)` - `*` - Declare a package-scope.
   * `(set! ..)`
+  * `(unless ..)`
   * `(when ..)`
   * `(while ..)`
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1140,8 +1140,30 @@ func (c *Compiler) emitExpr(e parser.Expr, ev *env.Env) error {
 
 		return fmt.Errorf("unknown variable: %s [package '%s']", n.Name, c.inPackage)
 
+	case *parser.Unless:
+		endLbl := c.label("unless")
+
+		err := c.emitExpr(n.Cond, ev)
+		if err != nil {
+			return err
+		}
+
+		c.emitln("    GET_TAG_BITS rax     ; get type bits")
+		c.emitln("    cmp rax, TAG_ID_NIL  ; is this a nil?")
+		c.emitln("    jnz " + endLbl)
+
+		// assemble the body
+		for _, expr := range n.Exprs {
+			err := c.emitExpr(expr, ev)
+			if err != nil {
+				return err
+			}
+		}
+
+		c.emitln(endLbl + ":")
+
 	case *parser.When:
-		endLbl := c.label("endwhen")
+		endLbl := c.label("when")
 
 		err := c.emitExpr(n.Cond, ev)
 		if err != nil {

--- a/examples/brainfuck.lisp
+++ b/examples/brainfuck.lisp
@@ -90,26 +90,26 @@ CHARACTERS and our interpreter doesn't understand character types."
         (cond
 
           ;; +
-          ((= ins "+") (do
+          ((= ins "+")
                         (let ((v (nth cells ptr)))
                           (nth! cells ptr (% (+ v 1) 256)))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; -
-          ((= ins "-") (do
+          ((= ins "-")
                         (let ((v (nth cells ptr)))
                           (nth! cells ptr (% (- v 1) 256)))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; >
-          ((= ins ">") (do
+          ((= ins ">")
                         (set! ptr (+ ptr 1))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; <
-          ((= ins "<") (do
+          ((= ins "<")
                         (set! ptr (- ptr 1))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; [
           ((= ins "[")
@@ -124,14 +124,14 @@ CHARACTERS and our interpreter doesn't understand character types."
                (set! i (+ (nth jumps i) 1))))
 
           ;; ,
-          ((= ins ".") (do
+          ((= ins ".")
                         (print (chr (nth cells ptr)))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; ,
-          ((= ins ",") (do
+          ((= ins ",")
                         (nth! cells ptr (getc))
-                        (set! i (+ i 1))))
+                        (set! i (+ i 1)))
 
           ;; skip over unknown instructions
           (t (set! i (+ i 1))))))))

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -23,6 +23,7 @@
 ;;   OR
 ;;   QUOTE
 ;;   SET!
+;;   UNLESS
 ;;   WHEN
 ;;   WHILE
 ;;
@@ -408,6 +409,8 @@
        (eval-quote expr env))
       ((= op "set!")
        (eval-set expr env))
+      ((= op "unless")
+       (eval-unless expr env))
       ((= op "when")
        (eval-when expr env))
       ((= op "while")
@@ -491,6 +494,13 @@
   (list
    (cadr expr)
    env))
+
+;; special form: unless
+(defun eval-unless (expr env)
+  (let ((r (eval (cadr expr) env)))
+    (if (eval-value r)
+        nil
+        (eval-body (cdr expr) env))))
 
 ;; special form: while
 (defun eval-when (expr env)

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -644,19 +644,17 @@
        (reverse (car args)))
 
       ((= name "print")
-       (do
         (while args
           (print (car args))
           (set! args (cdr args)))
-        nil))
+        nil)
 
       ((= name "println")
-       (do
         (while args
           (print (car args))
           (set! args (cdr args)))
         (print "\n")
-        nil))
+        nil)
 
       ((= name "seq")
        (seq (car args)))

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -164,6 +164,11 @@ type Set struct {
 	Expr Expr
 }
 
+type Unless struct {
+	Cond  Expr
+	Exprs []Expr
+}
+
 type When struct {
 	Cond  Expr
 	Exprs []Expr

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -595,6 +595,30 @@ func (p *Parser) parseList() (Expr, error) {
 				Expr: expr,
 			}, nil
 
+		case "unless":
+			cond, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+
+			var exprs []Expr
+
+			for p.peek() != ")" && p.peek() != "" {
+				x, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				exprs = append(exprs, x)
+			}
+
+			if !p.expectNext(")") {
+				return nil, fmt.Errorf("expected ')' after unless-expressions")
+			}
+
+			return &Unless{Cond: cond,
+				Exprs: exprs,
+			}, nil
+
 		case "when":
 			cond, err := p.parseExpr()
 			if err != nil {
@@ -612,7 +636,7 @@ func (p *Parser) parseList() (Expr, error) {
 			}
 
 			if !p.expectNext(")") {
-				return nil, fmt.Errorf("expected ')' after while-expressions")
+				return nil, fmt.Errorf("expected ')' after when-expressions")
 			}
 
 			return &When{Cond: cond,


### PR DESCRIPTION
This pull-request updates our compiler to understand the `unless` special form, which might be used like this:

    (unless (< i 0)
       (println "I'm positive")
       (println "and there are multiple expressions here"))

A good companion to `if`.

This closes #187.