### PR TITLE
Improve our lisp reader

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -172,6 +172,8 @@ added to them too.
      * Everything else returns an empty string.
   * `strlen`
     * Return the length of the given string.
+  * `substr`
+    * Return a substring from a given string.
   * `sys-gc`
     * Force our garbage collector to run.
   * `sys-heap-allocs`
@@ -298,8 +300,6 @@ The implementation of these primitives can be found in the file [stdlib.slisp](s
   * Return the first non-nil result of calling the given function against each item of the specified list.
 * `strstr`
   * Find a string within another.
-* `substr`
-  * Return a substring from a given string.
 * `sum`
   * Sum the values in the given list.
 * `system`

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -397,6 +397,20 @@ func (c *Compiler) Compile() (string, error) {
 	main := false
 
 	//
+	// We want to allow later functions to override earlier
+	// ones.
+	//
+	// So we iterate over our functions and save them in
+	// a hash - before processing that.
+	//
+	// This way:
+	//   (defun foo () (print "OK"))
+	//   (defun foo () (print "Hello, World"))
+	//
+	// Will mean "(foo) -> Hello, World"
+	tmp := make(map[string]parser.Defun)
+
+	//
 	// Generate the assembly for each known user-defined
 	// function to our internal buffer.
 	//
@@ -406,21 +420,26 @@ func (c *Compiler) Compile() (string, error) {
 		if !ok {
 			return nil
 		}
-
-		if d.Name == "main" {
-			main = true
-		}
-
-		err = c.emitCallable(d)
-		if err != nil {
-			return err
-		}
-		c.emitln("")
-
+		tmp[d.Name] = d
 		return nil
 	})
 	if err != nil {
 		return "", err
+	}
+
+	//
+	// Now emit them for real
+	//
+	for name, ent := range tmp {
+		if name == "main" {
+			main = true
+		}
+
+		err = c.emitCallable(ent)
+		if err != nil {
+			return "", err
+		}
+		c.emitln("")
 	}
 	if !main {
 		return "", fmt.Errorf("there is no entry-point defined; we need a defun named 'main'")

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -2560,6 +2560,65 @@ FUNC fn_sys_string
     jmp .copy_str_return       ; copy the resulting string into a new allocation
 
 
+FUNC fn_sys_substr
+    mov rbx, rdi            ; type-check arg1
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+
+    mov rbx, rsi            ; type-check offset
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_INTEGER
+    jne type_error
+
+    mov rbx, rdx            ; type-check length
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_INTEGER
+    jne type_error
+    UNTAG_REG rdi
+    UNTAG_REG rsi
+    UNTAG_REG rdx
+
+    push rdi                ; get length
+    call strlen
+    pop rdi
+
+    cmp rsi, rax           ; bounds check
+    ja out_of_range
+
+    push rdi               ; Allocate length
+    push rsi
+    push rdx
+    mov rax, rdx
+    inc rax                 ; +1 for null
+    mov rbx, TAG_ID_STRING
+    call alloc
+    mov rcx, rax           ; destination
+    mov r8,  rax      ; save original allocation pointer
+    pop rdx
+    pop rsi
+    pop rdi
+
+    add rdi, rsi           ; bump past the start
+
+.copy:
+    test rdx, rdx
+    jz .done
+
+    mov al, [rdi]
+    test al, al
+    jz .done
+    mov [rcx], al
+    inc rdi
+    inc rcx
+    dec rdx
+    jmp .copy
+
+.done:
+    mov byte [rcx], 0
+    mov rax, r8            ; restore pointer to string
+    TAG_STRING_REG rax
+    ret
 
 ;; Find the length of the given string.
 FUNC fn_sys_strlen

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -29,9 +29,12 @@
 ;;
 ;; We have a couple of builtin-functions we handle specially, but most are deferred to the
 ;; host/compiler's version of the code.
+
+
 ;;
-
-
+;; lisp-reader.lisp contains our reader/parser code.
+;;
+(require lisp-reader)
 
 ;; Our standard-library provides "(read-line)" but that
 ;; terminates on newline.  We want to read a complete
@@ -77,6 +80,7 @@
 (defun closure (params body env)
   (list "closure" params body env))
 
+;; Also declared in lisp-reader.lisp
 (defun symbol (name)
   (list "symbol" name))
 
@@ -746,227 +750,6 @@
       (eval-value result))))
 
 
-;;
-;; Reader
-;;
-(defvar *reader-text* "")
-(defvar *reader-pos* 0)
-
-(defun reader-init (text)
-  (set! *reader-text* text)
-  (set! *reader-pos* 0))
-
-(defun reader-eof ()
-  (>= *reader-pos*
-      (strlen *reader-text*)))
-
-(defun reader-peek ()
-  (if (reader-eof)
-      ""
-      (substr
-       *reader-text*
-       *reader-pos*
-       1)))
-
-(defun reader-next ()
-  (let ((ch (reader-peek)))
-    (set! *reader-pos* (+ *reader-pos* 1))
-    ch))
-
-
-;; Is the given value a number component "-", ".", and "0-9"
-(defun numeric-char? (ch)
-  (or
-   (= ch "-")
-   (= ch ".")
-   (= ch "0")
-   (= ch "1")
-   (= ch "2")
-   (= ch "3")
-   (= ch "4")
-   (= ch "5")
-   (= ch "6")
-   (= ch "7")
-   (= ch "8")
-   (= ch "9")))
-
-;; Is the given string 100% numeric-plausible?
-(defun number-string? (s)
-  (cond
-    ((= s "") nil)
-    ((= (substr s 0 1) "-")
-     (and
-      (> (strlen s) 1)
-      (number-string-aux s 1)))
-    (t
-     (number-string-aux s 0))))
-
-;; helper
-(defun number-string-aux (s pos)
-  (if (>= pos (strlen s))
-      t
-      (if (numeric-char?
-           (substr s pos 1))
-          (number-string-aux
-           s
-           (+ pos 1))
-          nil)))
-
-
-;; skip over whitespace and comments
-(defun reader-skip ()
-  (let ((again t))
-    (while again
-      (set! again nil)
-
-      ;; Skip whitespace
-      (while
-          (or
-           (= (reader-peek) " ")
-           (= (reader-peek) "\t")
-           (= (reader-peek) "\n")
-           (= (reader-peek) "\r"))
-        (reader-next))
-
-      ;; Skip a comment
-      (if (= (reader-peek) ";")
-          (let ()
-            (reader-skip-comment)
-            (set! again t))))))
-
-(defun reader-read ()
-  (reader-skip)
-  (cond
-    ((= (reader-peek) "(")
-     (reader-read-list))
-    ((= (reader-peek) ")")
-     (do
-      (println "unexpected ')' character.  Aborting")
-      (exit 1)))
-    ((= (reader-peek) "\"")
-     (reader-read-string))
-    ((= (reader-peek) "'")
-     (reader-next)
-     (list
-      (symbol "quote")
-      (reader-read)))
-    (t
-     (reader-read-atom))))
-
-(defun reader-skip-comment ()
-  ;; consume the ';'
-  (reader-next)
-
-  ;; skip until newline or EOF
-  (while
-      (and
-       (!= (reader-peek) "")
-       (!= (reader-peek) "\n"))
-    (reader-next))
-  ;; consume the newline if present
-  (if (= (reader-peek) "\n")
-      (reader-next)))
-
-(defun reader-read-list ()
-  ;; consume '('
-  (reader-next)
-  (let ((items nil))
-    (reader-skip)
-    (while (!= (reader-peek) ")")
-      (set! items
-            (cons
-             (reader-read)
-             items))
-      (reader-skip))
-    ;; consume ')'
-    (reader-next)
-    (reverse items)))
-
-(defun reader-read-string ()
-  (reader-next)   ; consume opening "
-
-  (let ((text ""))
-
-    (while
-        (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) "\""))
-
-      (if (= (reader-peek) "\\")
-          (do
-           (reader-next)     ; consume '\'
-
-           (let ((ch (reader-next)))
-             (set! text
-                   (strcat
-                    text
-                    (cond
-                      ((= ch "n") "\n")
-                      ((= ch "t") "\t")
-                      ((= ch "\"") "\"")
-                      ((= ch "\\") "\\")
-                      (t ch))))))
-          (set! text
-                (strcat
-                 text
-                 (reader-next)))))
-
-    (reader-next)    ; closing "
-    text))
-
-(defun reader-read-string-old ()
-  ;; consume opening "
-  (reader-next)
-  (let ((text ""))
-    (while
-        (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) "\""))
-      (set! text
-            (strcat
-             text
-             (reader-next))))
-
-    ;; consume closing "
-    (if (= (reader-peek) "\"")
-        (reader-next))
-    text))
-
-(defun reader-read-atom ()
-  (let ((token ""))
-    (while
-        (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) " ")
-         (!= (reader-peek) "\t")
-         (!= (reader-peek) "\r")
-         (!= (reader-peek) "\n")
-         (!= (reader-peek) "(")
-         (!= (reader-peek) ")"))
-
-      (set! token
-            (strcat
-             token
-             (reader-next))))
-
-    ;; Is this a number?
-    (if (number-string? token)
-        (atof token)
-        (symbol token))))
-
-
-;; parse a complete program and return all the expressions within it.
-(defun reader-parse-program ()
-  (let ((forms nil))
-    (reader-skip)
-    (while (not (reader-eof))
-      (set! forms
-            (cons
-             (reader-read)
-             forms))
-      (reader-skip))
-    (reverse forms)
-    ))
 
 ;; given a list of expressions, evaluate them all
 (defun eval-program (forms)

--- a/examples/lisp-reader.lisp
+++ b/examples/lisp-reader.lisp
@@ -1,0 +1,263 @@
+;;
+;; The lisp-reader package reads source code and returns lisp objects.
+;;
+;; It is designed to be included in other programs, and is included
+;; in that way by inception.lisp.
+;;
+;; There is a standalone `main` function at the foot of this file for
+;; running a self-contained test.  When other programs include it
+;; their own main functions will override the one here.
+;;
+
+;; The source we parse goes here.
+(defvar *reader-text* "")
+
+;; The position we're at goes here.
+(defvar *reader-pos* 0)
+
+;; Helper.
+(defun symbol (name)
+  (list "symbol" name))
+
+
+(defun reader-init (text)
+  (set! *reader-text* text)
+  (set! *reader-pos* 0))
+
+(defun reader-eof ()
+  (>= *reader-pos*
+      (strlen *reader-text*)))
+
+(defun reader-peek ()
+  (if (reader-eof)
+      ""
+      (substr
+       *reader-text*
+       *reader-pos*
+       1)))
+
+(defun reader-next ()
+  (let ((ch (reader-peek)))
+    (set! *reader-pos* (+ *reader-pos* 1))
+    ch))
+
+
+;; Is the given value a number component "-", ".", and "0-9"
+(defun numeric-char? (ch)
+  (or
+   (= ch "-")
+   (= ch ".")
+   (= ch "0")
+   (= ch "1")
+   (= ch "2")
+   (= ch "3")
+   (= ch "4")
+   (= ch "5")
+   (= ch "6")
+   (= ch "7")
+   (= ch "8")
+   (= ch "9")))
+
+;; Is the given string 100% numeric-plausible?
+(defun number-string? (s)
+  (cond
+    ((= s "") nil)
+    ((= (substr s 0 1) "-")
+     (and
+      (> (strlen s) 1)
+      (number-string-aux s 1)))
+    (t
+     (number-string-aux s 0))))
+
+;; helper
+(defun number-string-aux (s pos)
+  (if (>= pos (strlen s))
+      t
+      (if (numeric-char?
+           (substr s pos 1))
+          (number-string-aux
+           s
+           (+ pos 1))
+          nil)))
+
+
+;; skip over whitespace and comments
+(defun reader-skip ()
+  (let ((again t))
+    (while again
+      (set! again nil)
+
+      ;; Skip whitespace
+      (while
+          (or
+           (= (reader-peek) " ")
+           (= (reader-peek) "\t")
+           (= (reader-peek) "\n")
+           (= (reader-peek) "\r"))
+        (reader-next))
+
+      ;; Skip a comment
+      (if (= (reader-peek) ";")
+          (let ()
+            (reader-skip-comment)
+            (set! again t))))))
+
+(defun reader-read ()
+  (reader-skip)
+  (cond
+    ((= (reader-peek) "(")
+     (reader-read-list))
+    ((= (reader-peek) ")")
+     (do
+      (println "unexpected ')' character.  Aborting")
+      (exit 1)))
+    ((= (reader-peek) "\"")
+     (reader-read-string))
+    ((= (reader-peek) "'")
+     (reader-next)
+     (list
+      (symbol "quote")
+      (reader-read)))
+    (t
+     (reader-read-atom))))
+
+(defun reader-skip-comment ()
+  ;; consume the ';'
+  (reader-next)
+
+  ;; skip until newline or EOF
+  (while
+      (and
+       (!= (reader-peek) "")
+       (!= (reader-peek) "\n"))
+    (reader-next))
+  ;; consume the newline if present
+  (if (= (reader-peek) "\n")
+      (reader-next)))
+
+(defun reader-read-list ()
+  ;; consume '('
+  (reader-next)
+  (let ((items nil))
+    (reader-skip)
+    (while (!= (reader-peek) ")")
+      (set! items
+            (cons
+             (reader-read)
+             items))
+      (reader-skip))
+    ;; consume ')'
+    (reader-next)
+    (reverse items)))
+
+(defun reader-read-string ()
+  (reader-next)   ; consume opening "
+
+  (let ((text ""))
+
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) "\""))
+
+      (if (= (reader-peek) "\\")
+          (do
+           (reader-next)     ; consume '\'
+
+           (let ((ch (reader-next)))
+             (set! text
+                   (strcat
+                    text
+                    (cond
+                      ((= ch "n") "\n")
+                      ((= ch "t") "\t")
+                      ((= ch "\"") "\"")
+                      ((= ch "\\") "\\")
+                      (t ch))))))
+          (set! text
+                (strcat
+                 text
+                 (reader-next)))))
+
+    (reader-next)    ; closing "
+    text))
+
+(defun reader-read-string-old ()
+  ;; consume opening "
+  (reader-next)
+  (let ((text ""))
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) "\""))
+      (set! text
+            (strcat
+             text
+             (reader-next))))
+
+    ;; consume closing "
+    (if (= (reader-peek) "\"")
+        (reader-next))
+    text))
+
+(defun reader-read-atom ()
+  (let ((token ""))
+    (while
+        (and
+         (!= (reader-peek) "")
+         (!= (reader-peek) " ")
+         (!= (reader-peek) "\t")
+         (!= (reader-peek) "\r")
+         (!= (reader-peek) "\n")
+         (!= (reader-peek) "(")
+         (!= (reader-peek) ")"))
+
+      (set! token
+            (strcat
+             token
+             (reader-next))))
+
+    ;; Is this a number?
+    (if (number-string? token)
+        (atof token)
+        (symbol token))))
+
+
+;; parse a complete program and return all the expressions within it.
+(defun reader-parse-program ()
+  (let ((forms nil))
+    (reader-skip)
+    (while (not (reader-eof))
+      (set! forms
+            (cons
+             (reader-read)
+             forms))
+      (reader-skip))
+    (reverse forms)
+    ))
+
+
+;;;
+;;; Test Code
+;;;
+(defun reader-dump-program(path)
+  (let ((handle (fopen path "r"))  ; open
+        (data   (fread handle))    ; read
+        (res    (fclose handle)))  ; close
+    (when data
+      (reader-init data)
+      (println path ":")
+      (println (reader-parse-program)))))
+
+
+;;
+;; Dump all arguments, or just the named one.
+;;
+;; args.lisp is small enough to be parsed quickly.
+;;
+(defun main(args)
+  (if (nil? args)
+      (reader-dump-program "args.lisp")
+      (if (= 1 (length args))
+          (reader-dump-program "args.lisp")
+          (map (lambda (x) (reader-dump-program x)) (cdr args)))))

--- a/examples/lisp-reader.lisp
+++ b/examples/lisp-reader.lisp
@@ -49,64 +49,31 @@
     (set! *reader-pos* (+ *reader-pos* 1))
     ch))
 
+;; is the character whitespace?
+(defun whitespace? (ch)
+  (or (= ch " ")
+      (= ch "\t")
+      (= ch "\n")
+      (= ch "\r")))
 
-;; Is the given value a number component "-", ".", and "0-9"
-(defun numeric-char? (ch)
-  (or
-   (= ch "-")
-   (= ch ".")
-   (= ch "0")
-   (= ch "1")
-   (= ch "2")
-   (= ch "3")
-   (= ch "4")
-   (= ch "5")
-   (= ch "6")
-   (= ch "7")
-   (= ch "8")
-   (= ch "9")))
-
-;; Is the given string 100% numeric-plausible?
-(defun number-string? (s)
-  (cond
-    ((= s "") nil)
-    ((= (substr s 0 1) "-")
-     (and
-      (> (strlen s) 1)
-      (number-string-aux s 1)))
-    (t
-     (number-string-aux s 0))))
-
-;; helper
-(defun number-string-aux (s pos)
-  (if (>= pos (strlen s))
-      t
-      (if (numeric-char?
-           (substr s pos 1))
-          (number-string-aux
-           s
-           (+ pos 1))
-          nil)))
-
-
-;; skip over whitespace and comments
+;; Skip to the next token
 (defun reader-skip ()
-  (let ((again t))
+  (let ((again t)
+        (ch ""))
+
     (while again
       (set! again nil)
 
+      (set! ch (reader-peek))
+
       ;; Skip whitespace
-      (while
-          (or
-           (= (reader-peek) " ")
-           (= (reader-peek) "\t")
-           (= (reader-peek) "\n")
-           (= (reader-peek) "\r"))
-        (reader-next))
+      (while (whitespace? ch)
+        (reader-next)
+        (set! ch (reader-peek)))
 
       ;; Skip a comment
-      (if (= (reader-peek) ";")
-          (let ()
+      (if (= ch ";")
+          (do
             (reader-skip-comment)
             (set! again t))))))
 
@@ -133,15 +100,20 @@
   ;; consume the ';'
   (reader-next)
 
-  ;; skip until newline or EOF
-  (while
-      (and
-       (!= (reader-peek) "")
-       (!= (reader-peek) "\n"))
-    (reader-next))
-  ;; consume the newline if present
-  (if (= (reader-peek) "\n")
-      (reader-next)))
+  (let ((ch (reader-peek)))
+
+    ;; skip until newline or EOF
+    (while
+        (and
+         (!= ch "")
+         (!= ch "\n"))
+
+      (reader-next)
+      (set! ch (reader-peek)))
+
+    ;; consume the newline if present
+    (if (= ch "\n")
+        (reader-next))))
 
 (defun reader-read-list ()
   ;; consume '('
@@ -159,60 +131,115 @@
     (reverse items)))
 
 (defun reader-read-string ()
-  (reader-next)   ; consume opening "
+  ;; consume opening "
+  (reader-next)
 
-  (let ((text ""))
+  (let ((text "")
+        (ch (reader-peek)))
 
     (while
         (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) "\""))
+         (!= ch "")
+         (!= ch "\""))
 
-      (if (= (reader-peek) "\\")
+      (if (= ch "\\")
           (do
-           (reader-next)     ; consume '\'
+            ;; consume '\'
+            (reader-next)
 
-           (let ((ch (reader-next)))
-             (set! text
-                   (strcat
-                    text
-                    (cond
-                      ((= ch "n") "\n")
-                      ((= ch "t") "\t")
-                      ((= ch "\"") "\"")
-                      ((= ch "\\") "\\")
-                      (t ch))))))
-          (set! text
-                (strcat
-                 text
-                 (reader-next)))))
+            ;; read escaped character
+            (set! ch (reader-next))
 
-    (reader-next)    ; closing "
+            (set! text
+                  (strcat
+                   text
+                   (cond
+                     ((= ch "n") "\n")
+                     ((= ch "t") "\t")
+                     ((= ch "\"") "\"")
+                     ((= ch "\\") "\\")
+                     (t ch))))
+
+            ;; peek next character
+            (set! ch (reader-peek)))
+
+          (do
+            ;; consume ordinary character
+            (reader-next)
+
+            (set! text
+                  (strcat text ch))
+
+            ;; peek next character
+            (set! ch (reader-peek)))))
+
+    ;; consume closing quote
+    (if (= ch "\"")
+        (reader-next))
+
     text))
 
+(defun digit? (ch)
+  (or (= ch "0")
+      (= ch "1")
+      (= ch "2")
+      (= ch "3")
+      (= ch "4")
+      (= ch "5")
+      (= ch "6")
+      (= ch "7")
+      (= ch "8")
+      (= ch "9")))
 
 (defun reader-read-atom ()
-  (let ((token ""))
+  (let ((token "")
+        (numeric t)
+        (seen-digit nil)
+        (seen-dot nil)
+        (pos 0)
+        (ch (reader-peek)))
+
     (while
         (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) " ")
-         (!= (reader-peek) "\t")
-         (!= (reader-peek) "\r")
-         (!= (reader-peek) "\n")
-         (!= (reader-peek) "(")
-         (!= (reader-peek) ")"))
+         (!= ch "")
+         (!= ch " ")
+         (!= ch "\t")
+         (!= ch "\r")
+         (!= ch "\n")
+         (!= ch "(")
+         (!= ch ")"))
 
-      (set! token
-            (strcat
-             token
-             (reader-next))))
+      ;; consume the character we've already peeked
+      (reader-next)
 
-    ;; Is this a number?
-    (if (number-string? token)
+      (set! token (strcat token ch))
+
+      ;; Update numeric state
+      (if numeric
+          (cond
+            ((digit? ch)
+             (set! seen-digit t))
+
+            ((= ch ".")
+             (if seen-dot
+                 (set! numeric nil)
+                 (set! seen-dot t)))
+
+            ((= ch "-")
+             (if (!= pos 0)
+                 (set! numeric nil)))
+
+            (t
+             (set! numeric nil))))
+
+      (set! pos (+ pos 1))
+
+      ;; Peek once for the next iteration
+      (set! ch (reader-peek)))
+
+    (if (and numeric seen-digit)
         (atof token)
         (symbol token))))
-
 
 ;; parse a complete program and return all the expressions within it.
 (defun reader-parse-program ()

--- a/examples/lisp-reader.lisp
+++ b/examples/lisp-reader.lisp
@@ -9,26 +9,33 @@
 ;; their own main functions will override the one here.
 ;;
 
-;; The source we parse goes here.
-(defvar *reader-text* "")
+;; The length of the program.
+(defvar *reader-length* 0)
 
 ;; The position we're at goes here.
-(defvar *reader-pos* 0)
+(defvar *reader-pos*    0)
+
+;; The source we parse goes here.
+(defvar *reader-text*   "")
 
 ;; Helper.
 (defun symbol (name)
   (list "symbol" name))
 
 
+;; constructor
 (defun reader-init (text)
-  (set! *reader-text* text)
-  (set! *reader-pos* 0))
+  "Setup state for processing the given text input."
+  (set! *reader-length* (strlen text))
+  (set! *reader-pos* 0)
+  (set! *reader-text* text))
 
 (defun reader-eof ()
-  (>= *reader-pos*
-      (strlen *reader-text*)))
+  "Have we reached the end of our input?"
+  (>= *reader-pos* *reader-length*))
 
 (defun reader-peek ()
+  "Look at the next character, without consuming it"
   (if (reader-eof)
       ""
       (substr
@@ -37,6 +44,7 @@
        1)))
 
 (defun reader-next ()
+  "Return the next character"
   (let ((ch (reader-peek)))
     (set! *reader-pos* (+ *reader-pos* 1))
     ch))

--- a/examples/lisp-reader.lisp
+++ b/examples/lisp-reader.lisp
@@ -182,23 +182,6 @@
     (reader-next)    ; closing "
     text))
 
-(defun reader-read-string-old ()
-  ;; consume opening "
-  (reader-next)
-  (let ((text ""))
-    (while
-        (and
-         (!= (reader-peek) "")
-         (!= (reader-peek) "\""))
-      (set! text
-            (strcat
-             text
-             (reader-next))))
-
-    ;; consume closing "
-    (if (= (reader-peek) "\"")
-        (reader-next))
-    text))
 
 (defun reader-read-atom ()
   (let ((token ""))

--- a/examples/lisp-reader.test.expected
+++ b/examples/lisp-reader.test.expected
@@ -1,0 +1,2 @@
+args.lisp:
+(((symbol require) (symbol arg-parser)) ((symbol defun) (symbol main) ((symbol args)) ((symbol let) (((symbol parser) ((symbol arg-parser:new) ((symbol cdr) (symbol args))))) ((symbol println) Flags  ((symbol parser) (symbol :flags))) ((symbol println) Files  ((symbol parser) (symbol :files))))))

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -787,7 +787,6 @@ Incrementing by the given step each time."
 
 (defun substr (str start &len)
   "Return a substring of the given string"
-  (let ((chars (drop start (explode str))))
-    (if len
-        (implode (take (car len) chars))
-        (implode chars))))
+  (if len
+      (sys_substr str start (car len))
+      (sys_substr str start 1)))

--- a/test/overwrite.lisp
+++ b/test/overwrite.lisp
@@ -1,0 +1,11 @@
+;; Test that latest function wins, for duplicate names
+
+(defun foo ()
+  (println "I should be invisible"))
+
+(defun foo ()
+  (println "Hello, World!"))
+
+
+(defun main ()
+  (foo))

--- a/test/overwrite.test.expected
+++ b/test/overwrite.test.expected
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
This pull-request, once complete, will reduce the time taken to parse lisp.

The main goal is to speed things up, but to make that possible we're going to move the reader into its own package - and include it from the inception-interpretter.

Logically it makes sens to have:

* lisp-reader.lisp
   *  parser code ..
   * main driver to test it
* inception.lisp
  * `(require lisp-reader)`
  * code ..

However when I did that I immediately saw that definining `(defun main ..` in the reader package and the inception package would be an error.  So to be complete this pull-request needs to do a bunch of things:

* [x] Allow multiple definitions of functions.  Last one wins.
* [x] Move the reader into its own file, and load it from inception.
* [ ] Finally optimize the reader to close the real issue.

Once complete this will close #196