### PR TITLE
Implement support for fetching heap data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The `(cons ..)` primitive is a lisp-fundamental, so I figure that is going to be
 * `(sys-heap-allocs)` -  Return the number of memory allocations made since the last garbage-collection process.
   * If your program regularly calls `cons` this will never be more than 64,000.
 * `(sys-heap-bytes)` - Return the size of the heap.
+* `(sys-heap-data)` - Return the contents of the heap as a list of entries.
 * `(sys-heap-dump)` - Dump a summary of the heap to the console.
   * This is implemented in assembly and literally writes to STDOUT.  There is no control over the formatting.
   * I wanted to write a function that would return a list of heap entries, but that might trigger a GC process.  Which would invalidate the results mid-traversal, so this is my compromise solution.

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -1136,6 +1136,80 @@ FUNC fn_sysMINUSheapMINUSbytes
     TAG_INTEGER_REG rax
     ret
 
+
+;; Return a list describing every heap object.
+FUNC fn_sysMINUSheapMINUSdata
+    mov     r12, [from_space]
+    mov     r13, [alloc_ptr]
+
+    xor     r15, r15
+    TAG_NIL_REG r15              ; result list
+
+.loop:
+    cmp     r12, r13
+    jae     .reverse
+
+    lea     r14, [r12 + OBJ_PAYLOAD]  ; object
+    shl     r14, 3
+    mov     eax, [r12 + OBJ_TYPE]
+    or      r14, rax
+
+    mov     rbx, [r12 + OBJ_SIZE] ; size
+    shl     rbx, 3
+
+    mov     rcx, r12          ; offset
+    sub     rcx, [from_space]
+    shl     rcx, 3
+
+    mov     rdi, r14          ; object
+    xor     rsi, rsi
+    TAG_NIL_REG rsi
+    call    fn_sys_cons_NOGC  ; No GC during this
+    mov     r14, rax
+
+    mov     rdi, rbx          ; size
+    mov     rsi, r14
+    call    fn_sys_cons_NOGC  ; No GC during this
+    mov     r14, rax
+
+    mov     rdi, rcx          ; offset
+    mov     rsi, r14
+    call    fn_sys_cons_NOGC  ; No GC during this
+    mov     r14, rax
+
+    mov     rdi, r14          ; prepend
+    mov     rsi, r15
+    call    fn_sys_cons_NOGC  ; No GC during this
+    mov     r15, rax
+
+    mov     rax, [r12 + OBJ_SIZE]  ; next object
+    add     r12, rax
+    jmp     .loop
+
+.reverse:
+    xor     r14, r14
+    TAG_NIL_REG r14
+
+.rev_loop:
+    mov     rax, r15
+    mov     rcx, rax
+    and     rcx, 7
+    cmp     rcx, TAG_ID_NIL
+    je      .done
+
+    mov     rax, r15
+    UNTAG_REG rax
+    mov     rdi, [rax]           ; car
+    mov     r15, [rax+8]         ; cdr
+    mov     rsi, r14
+    call    fn_sys_cons_NOGC     ; No GC during this
+    mov     r14, rax
+    jmp     .rev_loop
+.done:
+    mov     rax, r14
+    ret
+
+
 ;; Dump heap contents.
 FUNC fn_sysMINUSheapMINUSdump
     mov     rcx, [from_space]      ; current object

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -273,6 +273,7 @@
   (register-builtin "sys-gc" (lambda (args) (sys-gc)))
   (register-builtin "sys-heap-allocs" (lambda (args) (sys-heap-allocs)))
   (register-builtin "sys-heap-bytes" (lambda (args) (sys-heap-bytes)))
+  (register-builtin "sys-heap-data" (lambda (args) (sys-heap-data)))
   (register-builtin "sys-heap-dump" (lambda (args) (sys-heap-dump)))
   (register-builtin "sys-heap-objects" (lambda (args) (sys-heap-objects)))
   (register-builtin "sys_run" (lambda (args) (sys_run (car args) (cadr args))))


### PR DESCRIPTION
This allows the heap to be dumped via lisp, and processed in arbitrary ways.

Example:

```lisp
(defun leftpad (str n)
  "Left-pad the given string with spaces until it reaches the specified size"
  (while (< (length str) n)
    (set! str (strcat " " str)))
  str)

(defun dump-heap()
  "Dump all items on the heap in sorted order"
  (map (lambda (ent)
           (let ((offset (nth ent 0))
                 (size   (nth ent 1))
                 (obj    (nth ent 2)))
             (print "offset:" (leftpad (string offset) 8) "\tsize:" (leftpad (string size) 8) "\t")
             (if (char? obj)   (println "char:" obj))    ; can't happen
             (if (cons? obj)   (println "cons:" obj))
             (if (float? obj)  (println "float:" obj))
             (if (int? obj)    (println "int:" obj))     ; can't happen
             (if (lambda? obj) (println "lambda:" obj))
             (if (nil? obj)    (println "nil:" obj))
             (if (str? obj)    (println "string: \"" obj "\""))
             ))
       (sys-heap-data)))

(defun main()

  ;; startup should be smallish
  (println "Dumping heap on startup")
  (sys-heap-dump)

  ;; Make a list of 100 numbers
  (let ((l (nat 100)))
    (println "Dumping heap after making a big list")
    (dump-heap)
  )

  (println "Dumping heap again after running GC")
  (sys-gc)
  (dump-heap)
  )
```

This closes #197.