### PR TITLE
Implement new primitive `(now)`

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -134,6 +134,8 @@ added to them too.
     * Create the named directory.  **NOTE**: Mode is fixed at 0755, and parent directories must exist unless you use `mkdirs`.
   * `newline`
     * Print a newline.
+  * `now`
+    * Get the milliseconds past the epoch.
   * `not`
     * If the supplied value is `nil` return 1, otherwise return `nil`.
   * `nth`

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -48,22 +48,23 @@
 ;; syscalls - searchable list online here
 ;;  https://filippo.io/linux-syscall-table/
 
-SYS_read        equ 0
-SYS_write       equ 1
-SYS_open        equ 2
-SYS_close       equ 3
-SYS_stat        equ 4
-SYS_lseek       equ 8
-SYS_dup2        equ 33
-SYS_fork        equ 57
-SYS_exec        equ 59
-SYS_exit        equ 60
-SYS_wait4       equ 61
-SYS_mkdir       equ 83
-SYS_rmdir       equ 84
-SYS_unlink      equ 87
-SYS_getdents64  equ 217
-SYS_getrandom   equ 318
+SYS_read          equ   0
+SYS_write         equ   1
+SYS_open          equ   2
+SYS_close         equ   3
+SYS_stat          equ   4
+SYS_lseek         equ   8
+SYS_dup2          equ  33
+SYS_fork          equ  57
+SYS_exec          equ  59
+SYS_exit          equ  60
+SYS_wait4         equ  61
+SYS_mkdir         equ  83
+SYS_rmdir         equ  84
+SYS_unlink        equ  87
+SYS_getdents64    equ 217
+SYS_clock_gettime equ 228
+SYS_getrandom     equ 318
 
 
 ;; (entries)
@@ -2038,6 +2039,32 @@ FUNC fn_sys_mkdir
 .failure:
     xor rax,rax
     TAG_NIL_REG rax
+    ret
+
+
+;; Get milliseconds since epoc
+FUNC fn_now
+    sub rsp, 16                  ; Reserve space for struct timespec
+
+    mov eax, SYS_clock_gettime
+    mov edi, 0                   ; CLOCK_REALTIME
+    mov rsi, rsp
+    syscall
+
+    ; Convert to milliseconds:
+    ; ms = tv_sec * 1000 + tv_nsec / 1,000,000
+    mov rax, [rsp]               ; tv_sec
+    imul rax, rax, 1000
+    mov r8, rax                  ; Save seconds in ms
+    mov rax, [rsp+8]             ; tv_nsec
+    xor edx, edx
+    mov ecx, 1000000
+    div rcx                      ; RAX = tv_nsec / 1,000,000
+    add rax, r8                  ; Total milliseconds
+    add rsp, 16                  ; Free stack space
+
+    ; RAX now contains milliseconds since the Unix epoch
+    TAG_INTEGER_REG rax
     ret
 
 

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -259,6 +259,7 @@
   (register-builtin "nat" (lambda (args) (nat (car args))))
   (register-builtin "newline" (lambda (args) (newline)))
   (register-builtin "nil?" (lambda (args) (nil? (car args))))
+  (register-builtin "now" (lambda (args) (now)))
   (register-builtin "not" (lambda (args) (not (car args))))
   (register-builtin "nth!" (lambda (args) (nth! (car args) (cadr args) (caddr args))))
   (register-builtin "nth" (lambda (args) (nth (car args) (cadr args))))

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -371,7 +371,7 @@ NOTE: This is not a macro, so all arguments are evaluated."
   "Return 1 if the number is even, nil otherwise."
   (= (% n 2 ) 0))
 
-(defun max (&xs)
+(defun max (xs)
   "Return the maximum integer from the list of numbers supplied."
   (if (nil? xs)
       xs
@@ -380,7 +380,7 @@ NOTE: This is not a macro, so all arguments are evaluated."
                 (if (< a b) b a))
               (car xs))))
 
-(defun min (&xs)
+(defun min (xs)
   "Return the smallest integer from the list of numbers supplied."
   (if (nil? xs)
       xs


### PR DESCRIPTION
Returns the time since the epoch in milliseconds, which is useful for timing things.

Simple example:

     (println (now)) (system "sleep 0.1") (println (now))