### PR TITLE
Allow (require) to be used at runtime.

### DIFF
--- a/packages/tree.lisp
+++ b/packages/tree.lisp
@@ -114,6 +114,9 @@
 
 ;;; Tree functions
 
+;; Constructor.
+(defun tree:new()
+  nil)
 
 ;; Is there a key with the given name in the tree?
 ;;

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -139,6 +139,16 @@
 (defun random (n)
        (sys_random n))
 
+;; NOP: This is a special form in our compiler
+;; However if we make this then we can pretend
+;; we load packages.
+(defun require (x))
+
+;; Load all embedded packages, again this is a nop
+;; for compiled code, but inception can use it.
+(defun require-all()
+  (map (lambda (p) (require p)) (packages)))
+
 (defun rmdir (str)
        (sys_rmdir str))
 


### PR DESCRIPTION
This is a NOP for compiled code - though it does work in inception.

Using this stub we can then define `(require-all)` which, again, is useful only for inception.

Also added a constructor for the tree-package, to match that we have for alist/plist