### PR TITLE
Implemented `(help FUN)` and `(functions)` for inception

### DIFF
--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -155,6 +155,24 @@
   ;; return the name
   name)
 
+;; get all known functions
+(defun functions ()
+  "Print builtins followed by user-defined functions."
+  (map (lambda (name)
+         (print name " "))
+       (tree:keys *functions*))
+  (newline)
+  nil)
+
+;; get help information, if available
+(defun help (xs)
+  (let ((x (car xs)))
+    (if (cons? x)
+        (if (str? (caaddr x))
+            (println (caaddr x))
+            (println "No help available")))))
+
+
 ;; get a function, by name
 ;;
 ;; Check for the self-hosted/inception version of the entry first.
@@ -206,6 +224,8 @@
   (register-builtin "char?" (lambda (args) (char? (car args))))
   (register-builtin "cons?" (lambda (args) (cons? (car args))))
   (register-builtin "float?" (lambda (args) (float? (car args))))
+  (register-builtin "functions" (lambda (args) (functions)))
+  (register-builtin "help" (lambda (args) (help args)))
   (register-builtin "int?" (lambda (args) (int? (car args))))
   (register-builtin "lambda?" (lambda (args) (lambda? (car args))))
   (register-builtin "list" (lambda (args) args))
@@ -720,9 +740,12 @@
 ;; REPL code
 ;;
 (defun repl ()
-  (println "Welcome to lisp in slisp!")
+  (newline)
+  (println "Welcome to lisp in slisp; \e[1mInception\e[0m!")
   (println "Enter :quit to exit.")
-  (println "")
+  (println "NOTE: Help for many functions is available - e.g. (help print)")
+  (println "NOTE: Available functions may be listed with (functions)")
+  (newline)
 
   (init-builtins)
 

--- a/packages/tree.lisp
+++ b/packages/tree.lisp
@@ -131,6 +131,17 @@
               (tree:bound? (node-left tree) key)
               (tree:bound? (node-right tree) key)))))
 
+;; Get keys in our tree
+(defun tree:keys (tree)
+  (tree:keys-aux tree nil))
+
+(defun tree:keys-aux (tree acc)
+  (if (nil? tree)
+      acc
+      (tree:keys-aux
+        (node-left tree)
+        (cons (node-key tree)
+              (tree:keys-aux (node-right tree) acc)))))
 
 ;; Get an item from the tree
 (defun tree:get (tree key)


### PR DESCRIPTION
This is so lovely to see:

```
$ ./inception --repl
Loaded stdlib.lisp in 1094ms.

Welcome to lisp in slisp; Inception!
Enter :quit to exit.
NOTE: Help for many functions is available - e.g. (help print)
NOTE: Available functions may be listed with (functions)

> (functions)
! != % * + - / < <= = > >= abs alist:get alist:keys alist:new alist:remove alist:set alist:values and append atof atof-frac atof-unsigned atoi atoi-helper caaaar caaadr caaar caadar caaddr caadr caar cadaar cadadr cadar caddar cadddr caddr cadr car cdaaar cdaadr cdaar cdadar cdaddr cdadr cdar cddaar cddadr cddar cdddar cddddr cdddr cddr cdr chr cons dir? drop entries environment eq eq? equal even? every exists? exit explode fclose file? filter find find-helper flatten fopen fread fwrite getc getenv getenv-loop implode int intersect intersect-helper isqrt join join-by join-helper join-rest length lower map max member? min mkdir mkdirs mkdirs-helper nat neg? newline not now nth nth! null? odd? one? or ord package packages plist:get plist:keys plist:new plist:remove plist:set plist:values pos? pow print print_cons println putc random range read-line reduce repeat repeated require require-all reverse reverse-inner rmdir seq some split split-all split-all-helper sqrt stat stdlib str-prefix? strcat strcmp string string< string= string> strlen strstr strstr-helper substr sum system take union union-helper unlink upper which zero?

> (help upper)
Convert the given string to upper-case

```

This closes #219.