### PR TITLE
Simplify compilation steps

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -541,14 +541,14 @@ func (c *Compiler) Compile() (string, error) {
 	//
 	type Float struct {
 		Name  string
-		Value float64
+		Value string
 	}
 
 	floatLiterals := []Float{}
 	for id, str := range c.floats {
 		floatLiterals = append(floatLiterals, Float{
 			Name:  id,
-			Value: str})
+			Value: fmt.Sprintf("%f", str)})
 	}
 
 	//

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -518,33 +518,38 @@ func (c *Compiler) Compile() (string, error) {
 	lambdas := getCompiled()
 
 	//
-	// Build up a data-section for our string tables
+	// Define a structure to hold static strings,
+	// from our string-table
 	//
-	c.emitln("section .data")
+	type String struct {
+		Name  string
+		Value string
+	}
+
+	stringLiterals := []String{}
 	for id, str := range c.strings {
-		c.emitln("align 16")
-		c.emitln(id + ":")
-
-		// escape the "`" which are wrapped around the string.
-		str = strings.ReplaceAll(str, "`", "\\`")
-
-		c.emitln(fmt.Sprintf("     db `%s`, 0", str))
+		stringLiterals = append(stringLiterals,
+			String{
+				Name:  id,
+				Value: strings.ReplaceAll(str, "`", "\\`"),
+			})
 	}
 
-	// Now as a simple string
-	stringTable := getCompiled()
+	//
+	// Define a structure to hold static floats,
+	// from our float-table
+	//
+	type Float struct {
+		Name  string
+		Value float64
+	}
 
-	//
-	// Build up a data-section for our user-defined float
-	// literals
-	//
-	c.emitln("section .data")
+	floatLiterals := []Float{}
 	for id, str := range c.floats {
-		c.emitln("align 16")
-		c.emitln(id + ":")
-		c.emitln(fmt.Sprintf("     dq %f", str))
+		floatLiterals = append(floatLiterals, Float{
+			Name:  id,
+			Value: str})
 	}
-	floatTable := getCompiled()
 
 	//
 	// Define a structure to hold embedded assets
@@ -632,6 +637,9 @@ func (c *Compiler) Compile() (string, error) {
 		// The defintions of defun's we've seen.
 		Defuns string
 
+		// Floattable holds our floating point constants
+		FloatTable []Float
+
 		// Lambdas has all the lambda expressions we've seen.
 		Lambdas string
 
@@ -642,13 +650,10 @@ func (c *Compiler) Compile() (string, error) {
 		Globals []string
 
 		// StringTable contains the strings we've seen.
-		StringTable string
+		StringTable []String
 
 		// Stdlib embeds our standard library
 		StdLib string
-
-		// FloatTable contains the floating point literals we've seen.
-		FloatTable string
 	}
 
 	// Trim our standard library
@@ -669,8 +674,8 @@ func (c *Compiler) Compile() (string, error) {
 		InitGlobals: initGlobals,
 		Lambdas:     lambdas,
 		StdLib:      stdLib,
-		StringTable: stringTable,
-		FloatTable:  floatTable,
+		StringTable: stringLiterals,
+		FloatTable:  floatLiterals,
 	}
 
 	// Create a buffer to render the template to.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -128,7 +128,14 @@ func New(src string) *Compiler {
 }
 
 // SetStdLib allows embedding the standard library
-func (c *Compiler) SetStdLib(s string) {
+func (c *Compiler) SetStdLib(s string) error {
+
+	// Before we encoded it strip the comments.
+	s, err := c.trimComments(s)
+	if err != nil {
+		return err
+	}
+
 	var b strings.Builder
 
 	b.WriteString("db ")
@@ -141,6 +148,7 @@ func (c *Compiler) SetStdLib(s string) {
 	}
 
 	c.stdlib = b.String() + "\ndb 0x00\n"
+	return nil
 }
 
 // trimComments processes the given text, and returns a copy without
@@ -156,7 +164,14 @@ func (c *Compiler) trimComments(str string) (string, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, ";") {
+
+		// Remove trailing comment.
+		if idx := strings.IndexRune(line, ';'); idx >= 0 {
+			line = line[:idx]
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
 
@@ -656,11 +671,6 @@ func (c *Compiler) Compile() (string, error) {
 		StdLib string
 	}
 
-	// Trim our standard library
-	stdLib, err1 := c.trimComments(c.stdlib)
-	if err1 != nil {
-		return "", err1
-	}
 	//
 	// Create an instance of that internal structure, which we
 	// can then pass to the template processor to fill out into
@@ -673,7 +683,7 @@ func (c *Compiler) Compile() (string, error) {
 		Globals:     globals,
 		InitGlobals: initGlobals,
 		Lambdas:     lambdas,
-		StdLib:      stdLib,
+		StdLib:      c.stdlib,
 		StringTable: stringLiterals,
 		FloatTable:  floatLiterals,
 	}

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -3684,7 +3684,13 @@ gc_scan_stack:
 
 section .data
 
-{{ .StringTable }}
+{{ range .StringTable }}
+align 16
+{{ .Name }}:
+        db `{{ .Value }}`
+        db 0x00
+{{end}}
+
 
 
 
@@ -3693,8 +3699,11 @@ section .data
 
 section .data
 
-{{ .FloatTable }}
+align 16
 
+{{ range .FloatTable }}{{ .Name }}:
+        dq {{ .Value }}
+{{end}}
 
 
 ;;; 9. global variables

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -3687,8 +3687,7 @@ section .data
 {{ range .StringTable }}
 align 16
 {{ .Name }}:
-        db `{{ .Value }}`
-        db 0x00
+        db `{{ .Value }}`, 0x00
 {{end}}
 
 
@@ -3699,9 +3698,9 @@ align 16
 
 section .data
 
+{{ range .FloatTable }}
 align 16
-
-{{ range .FloatTable }}{{ .Name }}:
+{{ .Name }}:
         dq {{ .Value }}
 {{end}}
 

--- a/main.go
+++ b/main.go
@@ -27,7 +27,10 @@ func generate(prg string) (string, error) {
 	c := compiler.New(prg)
 
 	// ensure it has access to the standard library
-	c.SetStdLib(stdlibLisp)
+	err := c.SetStdLib(stdlibLisp)
+	if err != nil {
+		return "", err
+	}
 
 	// Inline packages
 	c.LoadPackages(staticFiles)

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -879,7 +879,7 @@ Uses (environment) to get all environmental variables, and filters."
     text))
 
 (defun system(cmd)
-  "Run a command and return the output; nil on failure."
+  "Run a command and return the output."
   (let ((tmp     "/tmp/mktmp")         ; tmp file for output
         (res     (sys_run cmd tmp))    ; run command
         (handle  (fopen tmp "r"))      ; open file


### PR DESCRIPTION
Rather than "compiling" our string and floating-point literals into a stringbuffer instead just collect them in a slice, and output them via the text/template mechanism.

Our internal compilation still uses the string-buffers for everything else, but this is cleaner.

Also strip all comments from the stdlib before we embed it, including comments at the end of lines not just those at the start.
