### PR TITLE
Fixed broken tests.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -166,8 +166,12 @@ func (c *Compiler) trimComments(str string) (string, error) {
 		line = strings.TrimSpace(line)
 
 		// Remove trailing comment.
-		if idx := strings.IndexRune(line, ';'); idx >= 0 {
-			line = line[:idx]
+		if strings.HasPrefix(line, ";") {
+			line = strings.TrimPrefix(line, ";")
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
 		}
 
 		line = strings.TrimSpace(line)


### PR DESCRIPTION
Stripping comments from the middle of lines broke this section of code from packages/lisp-reader.lisp:

      ;; Skip a comment
      (if (= ch ";")
          (do
            (reader-skip-comment)
            (set! again t))))))

Which I failed to notice in my hasty way of committing to main.

This pull-request fixes things, at a cost of leaving trailing comments in-place.