### PR TITLE
Fix init

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -460,6 +460,18 @@ func (c *Compiler) Compile() (string, error) {
 	initGlobals := getCompiled()
 
 	//
+	// Compute the frame size, and the number of root-bytes the GC
+	// should scan for the variables setup as globals.  Just like we
+	// do for functions.
+	//
+	initGlobalsLocals := e.MaxOffset()
+	initGlobalsFrameSize := (initGlobalsLocals + 15) &^ 15
+	initGlobalsRootBytes := initGlobalsLocals - 8
+	if initGlobalsRootBytes < 0 {
+		initGlobalsRootBytes = 0
+	}
+
+	//
 	// Have we seen a "main" function, at the top-level
 	// (i.e. outside a package).
 	//
@@ -664,6 +676,16 @@ func (c *Compiler) Compile() (string, error) {
 		// InitGlobals is the thing that loads global variables
 		InitGlobals string
 
+		// InitGlobalsFrameSize is the stack frame size required
+		// for the global variables, setup ahead of main.
+		InitGlobalsFrameSize int
+
+		// InitGlobalsRootBytes similar story, bytes vs. size.
+		//
+		// To be honest this stuff needs to be reworked for all the
+		// places we care about stack size/bytes. (i.e. emitCallable).
+		InitGlobalsRootBytes int
+
 		// Globals has global variables
 		Globals []string
 
@@ -680,15 +702,17 @@ func (c *Compiler) Compile() (string, error) {
 	// the template appropriately.
 	//
 	x := &Generated{
-		Assets:      assets,
-		AssetCount:  len(assets),
-		Defuns:      defuns,
-		Globals:     globals,
-		InitGlobals: initGlobals,
-		Lambdas:     lambdas,
-		StdLib:      c.stdlib,
-		StringTable: stringLiterals,
-		FloatTable:  floatLiterals,
+		AssetCount:           len(assets),
+		Assets:               assets,
+		Defuns:               defuns,
+		FloatTable:           floatLiterals,
+		Globals:              globals,
+		InitGlobals:          initGlobals,
+		InitGlobalsFrameSize: initGlobalsFrameSize,
+		InitGlobalsRootBytes: initGlobalsRootBytes,
+		Lambdas:              lambdas,
+		StdLib:               c.stdlib,
+		StringTable:          stringLiterals,
 	}
 
 	// Create a buffer to render the template to.
@@ -1395,7 +1419,7 @@ func (c *Compiler) emitVariadicCall(name string, expected int, args []parser.Exp
 
 		c.emitln("    mov rdi,rax")
 		c.emitln(fmt.Sprintf("    mov rsi, [rbp-%d]", listTmp))
-		c.emitln("    call fn_cons")
+		c.emitln("    call fn_sys_cons_NOGC ; No GC during this operation")
 		c.emitln(fmt.Sprintf("    mov [rbp-%d], rax", listTmp))
 	}
 
@@ -1424,8 +1448,8 @@ func (c *Compiler) emitCallable(obj any) error {
 	// create new environment
 	ev := env.New(nil)
 
-	// Case the incoming object into a Defun,
-	// because the Lambda node actually embeds on.
+	// Cast the incoming object into a Defun, because the
+	// Lambda node actually embeds one and they are largely identical.
 	//
 	// We do need to add some lambda-specific generation
 	// between the prologue and epilogue, but that's small.

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -371,7 +371,7 @@ fn_init_globals:
     push rbp
     mov rbp, rsp
     push fn_fn_init_globals_gc
-    sub rsp, 64
+    sub rsp, {{ .InitGlobalsFrameSize }}
     {{ .InitGlobals }}
     leave
     ret
@@ -379,7 +379,7 @@ fn_init_globals:
 section .data
 fn_fn_init_globals_gc:
     dq 0x47430001
-    dq 48        ; root bytes
+    dq {{ .InitGlobalsRootBytes }}        ; root bytes
 
 section .text
 

--- a/examples/globals.lisp
+++ b/examples/globals.lisp
@@ -6,6 +6,32 @@
 ;; Attempting to change this will generate an error at compile-time.
 (defconst bar "i am unchanging")
 
+;; Declare some colours, as RGB values.
+(defvar blue    (list   0   0 255))
+(defvar midblue (list 20 174 244))
+(defvar pink    (list 255 192 203))
+(defvar green   (list   0 255   0))
+(defvar yellow  (list 255 255 224))
+(defvar cyan    (list   0 244 244))
+(defvar mustard (list 255 206  27))
+
+;; A scene we might pretend to draw.
+;;
+;; Mostly here to confirm we load things correctly in our
+;; init-code
+;;
+;; Ordering is important as we have no Z-index.
+(defvar scene
+  (list
+   (list "box" 350 150 400 300 pink)
+   (list "circle" 20 20 15 mustard)
+   (list "box" 0 0 20 400 blue)
+   (list "circle" 20 20 75 midblue)
+   (list "circle" 20 20 175  cyan)
+   (list "circle" 320 210 75 green )
+   (list "background" yellow)))
+
+
 (defun local ()
   "Test scoping by having a local variable with the same name as a global.
 
@@ -21,6 +47,8 @@ Spoiler: Local variable always comes first."
 (defun main (args)
   "Entry Point."
 
+  (sys-gc)
+
   ;; show global foo
   (println "global variable is:" foo)
 
@@ -32,6 +60,8 @@ Spoiler: Local variable always comes first."
 
   ;; Call a local function
   (local)
+
+  (sys-gc)
 
   (println "Global variable untouched:" foo)
 


### PR DESCRIPTION
Fix the frame size used for global init code.
    
We previously reserved 256 bytes of stack/frame space for functions, and then switched to calculating the real size because that was more efficient (and correct).
    
Similar story here, we were blindly reserving a fixed size for global inits, but that failed when we ran code like this
    
            (defun fun (list (list "steve" "blah")
                             (list 1 2 (/ 1.0 3))
                             ; ..
                ))
    
That would cause a segfault on startup, as the updated `examples/globals.lisp` test did, when I was experimenting with drawing graphics.

Now the tests pass and no more segfault.  I also switched to auto-calling the non-GC version of the `(list ..` primitive.  Not yet sure if that is a mistake.
