### PR TITLE
Implement, use, and document `strdup`.

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -177,6 +177,8 @@ added to them too.
     * Join two strings together and return them.
   * `strcmp`
     * Compare the two given strings, like the C-function this returns zero on equality.
+  * `strdup`
+    * Return a copy of the given string.
   * `string`
      * Convert characters, integers, and floats to strings.
      * Everything else returns an empty string.

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -64,7 +64,7 @@ SYS_rmdir         equ  84
 SYS_unlink        equ  87
 SYS_getdents64    equ 217
 SYS_clock_gettime equ 228
-SYS_prlimit64     equ 302       ; x86-64
+SYS_prlimit64     equ 302
 SYS_getrandom     equ 318
 
 ;; (entries)
@@ -299,12 +299,11 @@ _start:
     ;
     ; The end result was that our GC code was getting confused and didn't
     ; know what to do when processing the stack-local variables which
-    ; were "args"
+    ; were "args".
     ;
-    ; So here we have to essentially call "strdup" on each arg.  But we
-    ; don't have strdup as a primitive.  So instead we call '(strcat arg "")'
-    ; which has the side-effect of returning a heap-allocated copy of the
-    ; OS-provided argv[i] entry.
+    ; So here create a list of the command-line arguments, but rather than
+    ; using the raw strings we get are passed we have to call "strdup" on
+    ; each one.
     ;
     ; Life is hard.
     ;
@@ -317,19 +316,15 @@ _start:
 
     dec rcx
 
-    ; rdi = ""
-    mov rdi, empty_str
+    ; rdi = argv[i]
+    mov rdi, [rbx + rcx*8]
     TAG_STRING_REG rdi
-
-    ; rsi = argv[i]
-    mov rsi, [rbx + rcx*8]
-    TAG_STRING_REG rsi
 
     push rbx
     push rsi
     push rdi
     push rcx
-    call fn_sys_strcat        ; RAX = heap copy
+    call fn_sys_strdup        ; RAX = heap copy
     pop rcx
     pop rdi
     pop rsi
@@ -485,6 +480,19 @@ strlen:
     inc rax
     jmp .loop
 .done:
+    ret
+
+;; copy string from RDI into RDX, return RDX pointing after the copy
+strcpy:
+.loop:
+    mov bl,[rdi]
+    test bl,bl
+    jz .over
+    mov [rdx],bl
+    inc rdi
+    inc rdx
+    jmp .loop
+.over:
     ret
 
 
@@ -2657,26 +2665,39 @@ FUNC fn_sys_strcat
     pop rsi                  ; restore strings
     pop rdi
 
-.copy1:                      ; copy first
-    mov bl,[rdi]
-    test bl,bl
-    jz .copy2
-    mov [rdx],bl
-    inc rdi
-    inc rdx
-    jmp .copy1
+    call strcpy              ; copy first string
 
-.copy2:                      ; append second
-    mov bl,[rsi]
-    test bl,bl
-    jz .done
-    mov [rdx],bl
-    inc rsi
-    inc rdx
-    jmp .copy2
+    mov rdi, rsi             ; copy second string
+    call strcpy
 
 .done:                       ; terminate and return
     mov byte [rdx],0
+    TAG_STRING_REG rax
+    ret
+
+
+
+;; Return a heap-allocated copy of the given string
+FUNC fn_sys_strdup
+    mov rbx, rdi            ; type-check arg1: str
+    GET_TAG_BITS rbx
+    cmp rbx, TAG_ID_STRING
+    jne type_error
+    UNTAG_REG rdi
+
+    push rdi
+    call strlen              ; str is already in RDI, result in RAX
+    inc rax                  ; Add one for the NULL
+
+    mov rbx, TAG_ID_STRING
+    call alloc               ; make the allocation
+
+    mov rdx,rax              ; destination
+    pop rdi
+
+    call strcpy              ; Copy
+
+    mov byte [rdx],0         ; NULL terminate
     TAG_STRING_REG rax
     ret
 

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -307,6 +307,7 @@
   (register-builtin "sys_stdlib" (lambda (args) (sys_stdlib)))
   (register-builtin "sys_strcat" (lambda (args) (sys_strcat (car args) (cadr args))))
   (register-builtin "sys_strcmp" (lambda (args) (sys_strcmp (car args) (cadr args))))
+  (register-builtin "sys_strdup" (lambda (args) (sys_strdup (car args))))
   (register-builtin "sys_strlen" (lambda (args) (sys_strlen (car args))))
   (register-builtin "sys_substr" (lambda (args) (sys_substr (car args) (cadr args) (caddr args))))
   (register-builtin "sys_unlink" (lambda (args) (sys_unlink (car args))))

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -228,6 +228,10 @@ This returns a list of the form (TYPE SIZE MODE)."
   "Compare the two specified strings, return zero if equal."
   (sys_strcmp a b))
 
+(defun strdup(str)
+  "Return a heap-allocated copy of the given string."
+  (sys_strdup str))
+
 (defun string (x)
   "Convert the given item into a string, if possible."
   (sys_string x))

--- a/test/string.lisp
+++ b/test/string.lisp
@@ -1,23 +1,12 @@
-(defun pr (xs)
-  "Print each element of a list"
-  (if xs
-      (do
-       (print (car xs))
-       (pr (cdr xs)))))
-
 (defun showLen (x)
-  (pr (list "The length of : '" x "' is " (strlen x)))
-  (newline))
+  (println "The length of : '" x "' is " (strlen x)))
 
 (defun showCmp( a b )
-  (pr (list
+  (println
        "comparing a:" a
        " with b:" b
        " (strcmp a b): " (strcmp a b)
        " (= a b): " (= a b)))
-  (newline)
-  )
-
 
 (defun main (args)
   "Test strlen/strcmp"
@@ -30,8 +19,10 @@
   (showCmp "Steve" "Steve")
   (showCmp "Steve" "Rteve")
 
-  ; These should be identical
+  ; These should be identical even though the addresses will be different
   (showCmp "Hello" (implode (explode "Hello")))
+  (showCmp "Hello" (strdup "Hello"))
+  (showCmp "Hello" (strcat (strdup "Hell") (strdup "o")))
 
   ; string conversion
   (print (string "Hello!\n"))

--- a/test/string.test.expected
+++ b/test/string.test.expected
@@ -3,6 +3,8 @@ The length of : '' is 0
 comparing a:Steve with b:Steve (strcmp a b): 0 (= a b): 1
 comparing a:Steve with b:Rteve (strcmp a b): 1 (= a b): <nil>
 comparing a:Hello with b:Hello (strcmp a b): 0 (= a b): 1
+comparing a:Hello with b:Hello (strcmp a b): 0 (= a b): 1
+comparing a:Hello with b:Hello (strcmp a b): 0 (= a b): 1
 Hello!
 hello
 32


### PR DESCRIPTION
This is mostly a function that exists for our internal benefit, but there's no harm in documenting it.

This closes #231.