### PR TITLE
Run GC based on the size of the heap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ To start with I did the obvious thing and made the allocation region larger, ign
 
 The `(cons ..)` primitive is a lisp-fundamental, so I figure that is going to be called pretty often in user-programs, either directly or via the `(list ...)` wrapper.  But if that isn't the case you may also trigger the garbage-collection process explicitly, and see the stats via these methods:
 
-* `(sys-gc)` run the garbage collection process immediately.
+* `(sys-gc)` - run the garbage collection process immediately.
+* `(sys-gc-threshold)` - Get the size of the GC threshold, which might be changed by the `GC_THRESHOLD` environmental variable.
 * `(sys-heap-allocs)` -  Return the number of memory allocations made since the last garbage-collection process.
 * `(sys-heap-bytes)` - Return the size of the heap.
 * `(sys-heap-data)` - Return the contents of the heap as a list of entries.
@@ -355,13 +356,15 @@ The stop and copy implementation is pretty simple:
   * The `(cons ..)` primitive is the only one that is used to trigger "auto GC",  and we know `cons` can only be called with two arguments, so we only have to consider the two registers RDI & RSI.
   * TLDR; Our roots are "globals", "stack-locals", and potentially the contents of the two registers `rdi` and `rsi`.
 
-The garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but it you can adjust the threshold at runtime via the `GC_THRESHOLD` environmental variable:
+By default the garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but it you can adjust the threshold at runtime via the `GC_THRESHOLD` environmental variable:
 
     GC_THRESHOLD=500000 ./foo
     GC_THRESHOLD=64M    ./foo
     GC_THRESHOLD=1G     ./foo
 
-Setting the threshold too low will mean that your program will never complete.  If you set the size to be 5k, for example, and your program allocates 10k of objects which must persist will result in endless GC runs, as the size used is always above the threshold.  That's because we assume running the garbage collection will reduce the heap size, but if there are legitimately things stored there, it will never get bigger.
+Setting the threshold too low will mean that your program will never complete.  If you set the size to be 5k, for example, and your program allocates 10k of objects which must persist will result in endless GC runs, as the size used is always above the threshold.  That's because we assume running the garbage collection will reduce the heap size, but if there are legitimately things stored there, it will never shrink to be smaller than the threshold.
+
+> Advice: Leave the default limit, unless you observe too much thrashing, and then _increase_ it.  This will result in fewer, albeit longer, garbage collection cycles.
 
 
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,13 @@ The stop and copy implementation is pretty simple:
   * The `(cons ..)` primitive is the only one that is used to trigger "auto GC",  and we know `cons` can only be called with two arguments, so we only have to consider the two registers RDI & RSI.
   * TLDR; Our roots are "globals", "stack-locals", and potentially the contents of the two registers `rdi` and `rsi`.
 
-The garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but it you can adjust the threshold in the assembly which is generated.  If no heap size threshold is defined then instead the process is triggered after 200,000 allocations.  (But again this can be changed.)
+The garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but it you can adjust the threshold at runtime via the `GC_THRESHOLD` environmental variable:
+
+    GC_THRESHOLD=500000 ./foo
+    GC_THRESHOLD=64M    ./foo
+    GC_THRESHOLD=1G     ./foo
+
+Setting the threshold too low will mean that your program will never complete.  If you set the size to be 5k, for example, and your program allocates 10k of objects which must persist will result in endless GC runs, as the size used is always above the threshold.  That's because we assume running the garbage collection will reduce the heap size, but if there are legitimately things stored there, it will never get bigger.
 
 
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@ The `(cons ..)` primitive is a lisp-fundamental, so I figure that is going to be
 
 * `(sys-gc)` run the garbage collection process immediately.
 * `(sys-heap-allocs)` -  Return the number of memory allocations made since the last garbage-collection process.
-  * If your program regularly calls `cons` this will never be more than 64,000.
 * `(sys-heap-bytes)` - Return the size of the heap.
 * `(sys-heap-data)` - Return the contents of the heap as a list of entries.
 * `(sys-heap-dump)` - Dump a summary of the heap to the console.
@@ -355,6 +354,8 @@ The stop and copy implementation is pretty simple:
   * For register contents we cheat a little.
   * The `(cons ..)` primitive is the only one that is used to trigger "auto GC",  and we know `cons` can only be called with two arguments, so we only have to consider the two registers RDI & RSI.
   * TLDR; Our roots are "globals", "stack-locals", and potentially the contents of the two registers `rdi` and `rsi`.
+
+The garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but it you can adjust the threshold in the assembly which is generated.  If no heap size threshold is defined then instead the process is triggered after 200,000 allocations.  (But again this can be changed.)
 
 
 

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -444,38 +444,96 @@ section .text
 ;; environmental varialbe GC_THRESHOLD.  Here we look
 ;; for that variable, and parse it if we see it.
 ;;
+;; examples:
+;;
+;;   GC_THRESHOLD=500000  - raw number (B) implicit
+;;   GC_THRESHOLD=64M     - Mb
+;;   GC_THRESHOLD=1G      - Gb
+;;
 parse_gc_threshold:
     mov     rsi, [envp_ptr]
 .next_env:
     mov     rdi, [rsi]
     test    rdi, rdi
-    jz      .done              ; end of envp
+    jz      .done
     add     rsi, 8
     mov     rbx, gc_name
+
 .compare:
     mov     al, [rbx]
     test    al, al
-    jz      .matched           ; reached end of "GC_THRESHOLD="
+    jz      .matched
     cmp     al, [rdi]
     jne     .next_env
     inc     rbx
     inc     rdi
     jmp     .compare
+
+    ;;
+    ;; Parse decimal number
+    ;;
 .matched:
-    xor     rax, rax           ; parsed value = 0
-.parse:
+    xor     rax, rax
+.parse_digits:
     movzx   rcx, byte [rdi]
     sub     rcx, '0'
     cmp     rcx, 9
-    ja      .save              ; first non-digit
+    ja      .parse_suffix
     imul    rax, rax, 10
     add     rax, rcx
     inc     rdi
-    jmp     .parse
-.save:
+    jmp     .parse_digits
+
+    ;;
+    ;; Optional suffix
+    ;;
+.parse_suffix:
+    movzx   ecx, byte [rdi]
+
+    and     cl, 0DFh  ; Convert lower-case to upper
+    cmp     cl, 'K'
+    je      .kilobytes
+    cmp     cl, 'M'
+    je      .megabytes
+    cmp     cl, 'G'
+    je      .gigabytes
+    cmp     cl, 'T'
+    je      .terabytes
+    jmp     .store
+
+.kilobytes:
+    shl     rax, 10
+    inc     rdi
+    jmp     .optional_b
+
+.megabytes:
+    shl     rax, 20
+    inc     rdi
+    jmp     .optional_b
+
+.gigabytes:
+    shl     rax, 30
+    inc     rdi
+    jmp     .optional_b
+
+.terabytes:
+    shl     rax, 40
+    inc     rdi
+
+    ;; Optional trailing 'B'
+.optional_b:
+    movzx   ecx, byte [rdi]
+    and     cl, 0DFh
+    cmp     cl, 'B'
+    jne     .store
+    inc     rdi
+
+.store:
     mov     [gc_threshold_bytes], rax
 .done:
     ret
+
+
 
 ;;; 5. stdlib
 

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -53,6 +53,33 @@
 %undef  DEBUG_GC       ;; Disabled by default.
 ; %define DEBUG_GC 1   ;; Uncomment to enable.
 
+;;
+;; Size of our heap: 4Gb
+;;
+;; Remember of course we have two heaps, both of
+;; the same size.
+;;
+%define HEAP_SIZE        (4 * 1024 * 1024 * 1024)
+
+;;
+;; If more memory than this has been allocated we
+;; run our garbage collection process.
+;;
+;; The limit is arbitrarily set at 20Mb here.
+;;
+;; If this is NOT defined we instead fall back to running
+;; GC based on the number of memory allocations that have
+;; been made.
+;;
+%define GC_HEAP_USED_THRESHOLD         (20 * 1024 * 1024)
+
+;;
+;; Here's where we set the fallback limit on the number of
+;; allocations made.
+;;
+%define GC_ALLOCATION_THRESHOLD 200000
+
+
 
 ;; syscalls - searchable list online here
 ;;  https://filippo.io/linux-syscall-table/
@@ -3221,11 +3248,11 @@ gc_free:
 ;; Two heaps
 ;;
 heap_a:
-    resb 8 * 1024 * 1024 * 1024  ; 8 Gb
+    resb HEAP_SIZE
 heap_a_end:
 
 heap_b:
-    resb 8 * 1024 * 1024 * 1024  ; 8 Gb
+    resb HEAP_SIZE
 heap_b_end:
 
 
@@ -3277,10 +3304,20 @@ possibly_trigger_gc:
     push rbx
     push rax
 
+    ; Will we GC based on the size of the heap?
+%ifdef GC_HEAP_USED_THRESHOLD
+    mov     rax, [from_space]
+    add     rax, GC_HEAP_USED_THRESHOLD
+    mov     rcx, [alloc_ptr]
+    cmp     rcx, rax
+    jb      .ignore_gc
+%else
+    ; Fall back to the number of allocations
     mov rax, [alloc_count]
-    cmp rax, 64000                  ; Bill Gate's constant
-
+    cmp rax, GC_ALLOCATION_THRESHOLD
     jle .ignore_gc
+%endif
+
     mov [gc_stack_base], rbp        ; save caller's rbp (we have no prologue, so rbp is still theirs)
     mov qword [gc_forward_regs], 1  ; forward RSI and RDI
 

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -73,11 +73,6 @@
 ;;
 %define GC_HEAP_USED_THRESHOLD         (20 * 1024 * 1024)
 
-;;
-;; Here's where we set the fallback limit on the number of
-;; allocations made.
-;;
-%define GC_ALLOCATION_THRESHOLD 200000
 
 
 
@@ -386,6 +381,8 @@ _start:
     jmp .loop
 
 .done:
+    call parse_gc_threshold    ; See if we change the size of our GC threshold
+
     mov rdi, r12               ; args list
     call fn_init_globals       ; initialize global variables (i.e. top-level defvar/defconst.)
 
@@ -438,6 +435,47 @@ section .text
 
 
 
+;;
+;; We autoamatically run the GC process when the heap
+;; size exceeds a specific threshold.  By default this
+;; is 20Mb.
+;;
+;; We allow the user to change this threshold via the
+;; environmental varialbe GC_THRESHOLD.  Here we look
+;; for that variable, and parse it if we see it.
+;;
+parse_gc_threshold:
+    mov     rsi, [envp_ptr]
+.next_env:
+    mov     rdi, [rsi]
+    test    rdi, rdi
+    jz      .done              ; end of envp
+    add     rsi, 8
+    mov     rbx, gc_name
+.compare:
+    mov     al, [rbx]
+    test    al, al
+    jz      .matched           ; reached end of "GC_THRESHOLD="
+    cmp     al, [rdi]
+    jne     .next_env
+    inc     rbx
+    inc     rdi
+    jmp     .compare
+.matched:
+    xor     rax, rax           ; parsed value = 0
+.parse:
+    movzx   rcx, byte [rdi]
+    sub     rcx, '0'
+    cmp     rcx, 9
+    ja      .save              ; first non-digit
+    imul    rax, rax, 10
+    add     rax, rcx
+    inc     rdi
+    jmp     .parse
+.save:
+    mov     [gc_threshold_bytes], rax
+.done:
+    ret
 
 ;;; 5. stdlib
 
@@ -3150,6 +3188,17 @@ random_buffer:
     db 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 random_buffer_end:
 
+;;
+;; We allow the threshold to be set in the environmental variable,
+;; here we set the name.
+;;
+gc_name: db "GC_THRESHOLD=",0
+
+;;
+;; The default heap size at which we trigger GC
+;;
+gc_threshold_bytes: dq GC_HEAP_USED_THRESHOLD
+
 
 ;; zero section
 section .bss
@@ -3304,19 +3353,17 @@ possibly_trigger_gc:
     push rbx
     push rax
 
-    ; Will we GC based on the size of the heap?
-%ifdef GC_HEAP_USED_THRESHOLD
+    ; Has the heap size grown enough to trigger
+    ; a GC process?
+    ;
+    ; The threshold is set to 20Mb by default,
+    ; but the user can change the limit at runtime
+    ; via the GC_THRESHOLD environmental variable.
     mov     rax, [from_space]
-    add     rax, GC_HEAP_USED_THRESHOLD
+    add     rax, [gc_threshold_bytes]
     mov     rcx, [alloc_ptr]
     cmp     rcx, rax
     jb      .ignore_gc
-%else
-    ; Fall back to the number of allocations
-    mov rax, [alloc_count]
-    cmp rax, GC_ALLOCATION_THRESHOLD
-    jle .ignore_gc
-%endif
 
     mov [gc_stack_base], rbp        ; save caller's rbp (we have no prologue, so rbp is still theirs)
     mov qword [gc_forward_regs], 1  ; forward RSI and RDI

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -1932,11 +1932,19 @@ FUNC fn_sysMINUSgc
     ret
 
 
+;; return the GC threshold, in bytes
+FUNC fn_sysMINUSgcMINUSthreshold
+     mov rax, [gc_threshold_bytes]
+    TAG_INTEGER_REG rax
+    ret
+
+
 ;; Return the internal count the allocations.
 FUNC fn_sysMINUSheapMINUSallocs
     mov rax, [alloc_count]
     TAG_INTEGER_REG rax
     ret
+
 
 ;; return the size of the current heap, in bytes.
 FUNC fn_sysMINUSheapMINUSbytes

--- a/examples/inception.lisp
+++ b/examples/inception.lisp
@@ -256,6 +256,7 @@
   (register-builtin "str?" (lambda (args) (str? (car args))))
   (register-builtin "string" (lambda (args) (string (car args))))
   (register-builtin "sys-gc" (lambda (args) (sys-gc)))
+  (register-builtin "sys-gc-threshold" (lambda (args) (sys-gc-threshold)))
   (register-builtin "sys-stdlib-loaded" (lambda (args) (sys-stdlib-loaded)))
   (register-builtin "sys-heap-allocs" (lambda (args) (sys-heap-allocs)))
   (register-builtin "sys-heap-bytes" (lambda (args) (sys-heap-bytes)))


### PR DESCRIPTION
This pull-request changes the way that we decide when to run a garbage collection process; instead of being based on the number of allocations made it is now run if the size of the heap exceeds a static threshold.

To make this friendlier any compiled program may have the size changed at runtime, via the environmental variable `GC_THRESHOLD`. So you could run the nqueens program with a 64Mb threshold like this:

     GC_THRESHOLD=64M ./nqueens 10

This closes #236.