### PR TITLE
Avoid reseting the allocation count, and add at_exit

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -189,7 +189,7 @@ added to them too.
   * `sys-gc`
     * Force our garbage collector to run.
   * `sys-heap-allocs`
-    * Return the number of memory allocations that have been completed since our last GC.
+    * Return the number of memory allocations that have been completed.
   * `sys-heap-bytes`
     * Return the size of the heap, in bytes.
   * `sys-heap-objects`

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Setting the threshold too low will mean that your program will never complete.  
 
 > Advice: Leave the default limit, unless you observe too much thrashing, and then _increase_ it.  This will result in fewer, albeit longer, garbage collection cycles.
 
+The function `at_exit` is invoked, if it is defined, when all programs terminate cleanly.  The default handler will dump memory statistics on-exit if the environmental variable `GC_DUMP_STATS` is non-empty.
+
 
 
 ## Motivation

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -398,8 +398,16 @@ _start:
     pop rdi
 
     call fn_main               ; Call the user's code.
+    push rax                   ; Save their exit-code
 
-    mov rdi, rax               ; exit code is the last expression
+    cmp byte [at_exit_called], 0
+    jne .exit_called
+    mov byte [at_exit_called], 1
+    call fn_at_exit            ; Call the "at_exit" function.
+
+.exit_called:
+
+    pop rdi                    ; Restore their exit code into RDI
     UNTAG_REG rdi
     mov rax, SYS_exit
     syscall
@@ -1539,6 +1547,13 @@ FUNC fn_sys_environment
 
 ;; terminate execution with the given exit-code
 FUNC fn_sys_exit
+    push rdi
+    cmp byte [at_exit_called], 0
+    jne .exit_called
+    mov byte [at_exit_called], 1
+    call fn_at_exit            ; Call the "at_exit" function.
+.exit_called:
+    pop rdi
     UNTAG_REG rdi
     mov rax, SYS_exit
     syscall
@@ -3241,6 +3256,9 @@ align 16
 dash_c:
     db "-c",0
 
+;; Avoid calling the user's at_exit funciton more than once.
+at_exit_called:
+    db 0x00
 
 ;; buffer for our random function to read into.
 ;; other functions, such as getc, newline, use it
@@ -3702,8 +3720,6 @@ gc_collect:
     ret
 
 .run_gc:
-    mov qword [alloc_count], 0      ; reset the count of allocations now GC is running/has run.
-
     ;; Initialise the destination heap.
     mov     rax, [to_space]
     mov     [gc_scan], rax

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -1019,5 +1019,30 @@ If no length is specified return from the given start to the end of the string."
       (sys_substr str start (car len))
       (sys_substr str start (- (length str) start))))
 
+;; Declare an "at_exit" function, this is called *after* main terminates
+;;
+;; It is expected the user will override this, if they want to.
+(defun at_exit ()
+   ;; NOP
+  (if (> (length (getenv "GC_DUMP_STATS")) 0)
+      (let ((bytes (sys-heap-bytes))  ; bytes
+            (size  (lambda (n)
+                     (let ((suffix " bytes"))        ; with a suffix
+                       (when (> n 1024)
+                         (set! n (/ n 1024))
+                         (set! suffix "K"))
+                       (when (> n 1024)
+                         (set! n (/ n 1024))
+                         (set! suffix "M"))
+                       (when (> n 1024)
+                         (set! n (/ n 1024))
+                         (set! suffix "G"))
+                       (strcat (string n) suffix)))))
+
+        (println "\theap objects:" (sys-heap-objects))
+        (println "\theap size:" (size bytes) " heap-limit:" (size (sys-gc-threshold)))
+        (println "\tallocations:" (sys-heap-allocs)))))
+
+
 ;; We're loaded now.
 (defvar *stdlib* (sys-stdlib-loaded))


### PR DESCRIPTION
This pull-request closes #238 by doing two things:

* Calling the user's "at_exit" function, at exit-time.
* No longer resetting the allocation count, after we run GC

This means "alloc_count" is always valid, correct, and current.

We've installed a stub "at_exit" function which will dump memory-stats if GC_DUMP_STATS is non-empty like so:

```
frodo ~/slisp/examples $ echo 120  | GC_DUMP_STATS=1 brainfuck bf/factor.bf
120: 2 2 2 3 5
	heap objects:47615
	heap size:2M heap-limit:20M
	allocations:119457
frodo ~/slisp/examples $ GC_DUMP_STATS=1 brainfuck bf/hello-world.bf
Hello World!
	heap objects:1816
	heap size:88K heap-limit:20M
	allocations:1855
frodo ~/slisp/examples $
```

Of course we expect the user to override this function, and we ensure it is only called ONCE no matter how many times it might be invoked.