### PR TITLE
Revert back to counting allocations to trigger GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ To start with I did the obvious thing and made the allocation region larger, ign
 The `(cons ..)` primitive is a lisp-fundamental, so I figure that is going to be called pretty often in user-programs, either directly or via the `(list ...)` wrapper.  But if that isn't the case you may also trigger the garbage-collection process explicitly, and see the stats via these methods:
 
 * `(sys-gc)` - run the garbage collection process immediately.
-* `(sys-gc-threshold)` - Get the size of the GC threshold, which might be changed by the `GC_THRESHOLD` environmental variable.
+* `(sys-gc-threshold)` - We run the GC process after a fixed number of allocations have been made, this retrieves the value of that threshold.  Change it via the `GC_ALLOC_THRESHOLD` environmental variable.
 * `(sys-heap-allocs)` -  Return the number of memory allocations made since the last garbage-collection process.
 * `(sys-heap-bytes)` - Return the size of the heap.
 * `(sys-heap-data)` - Return the contents of the heap as a list of entries.
@@ -356,15 +356,12 @@ The stop and copy implementation is pretty simple:
   * The `(cons ..)` primitive is the only one that is used to trigger "auto GC",  and we know `cons` can only be called with two arguments, so we only have to consider the two registers RDI & RSI.
   * TLDR; Our roots are "globals", "stack-locals", and potentially the contents of the two registers `rdi` and `rsi`.
 
-By default the garbage collection process is triggered when more than 20Mb has been allocated within our heap (which is 4Gb), but if you wish you can adjust the threshold by setting `GC_THRESHOLD` environmental variable before you execute one of the compiled binaries:
+By default the garbage collection process is triggered when more than 1000 allocations have been made, but if you wish you can adjust the threshold by setting `GC_ALLOC_THRESHOLD` environmental variable before you execute one of the compiled binaries:
 
-    GC_THRESHOLD=500000 ./foo
-    GC_THRESHOLD=64M    ./foo
-    GC_THRESHOLD=1G     ./foo
+    GC_ALLOC_THRESHOLD=1      ./foo
+    GC_ALLOC_THRESHOLD=500000 ./foo
 
-Setting the threshold too low will mean that your program will never complete.  If you set the size to be 5k, for example, and your program allocates 10k of objects which must persist will result in endless GC runs, as the size used is always above the threshold.  That's because we assume running the garbage collection will reduce the heap size, but if there are legitimately things stored there, it will never shrink to be smaller than the threshold.
-
-> Advice: Leave the default limit, unless you observe too much thrashing, and then _increase_ it.  This will result in fewer, albeit longer, garbage collection cycles.
+Setting the threshold low will ensure the heap is as small as possible, at a cost that the garbage collector will run more frequently.  Setting it to a "mid-high" value is perhaps more efficient, the garbage collector will run less often, and do more work each time.  But chances are that time won't dominate the _total_ runtime, which is a risk if it is set too low.
 
 The function `at_exit` is invoked, if it is defined, when all programs terminate cleanly.  The default handler will dump memory statistics on-exit if the environmental variable `GC_DUMP_STATS` is non-empty.
 

--- a/compiler/template.tmpl
+++ b/compiler/template.tmpl
@@ -62,16 +62,11 @@
 %define HEAP_SIZE        (4 * 1024 * 1024 * 1024)
 
 ;;
-;; If more memory than this has been allocated we
-;; run our garbage collection process.
+;; If more than this number of memory allocations
+;; has been carried out we run the garbage collection
+;; process.
 ;;
-;; The limit is arbitrarily set at 20Mb here.
-;;
-;; If this is NOT defined we instead fall back to running
-;; GC based on the number of memory allocations that have
-;; been made.
-;;
-%define GC_HEAP_USED_THRESHOLD         (20 * 1024 * 1024)
+%define GC_ALLOCATION_THRESHOLD    100000
 
 
 
@@ -444,19 +439,17 @@ section .text
 
 
 ;;
-;; We autoamatically run the GC process when the heap
-;; size exceeds a specific threshold.  By default this
-;; is 20Mb.
+;; We automatically run the GC process when the number
+;; of allocations exceeds a specific threshold.
 ;;
 ;; We allow the user to change this threshold via the
-;; environmental varialbe GC_THRESHOLD.  Here we look
+;; environmental variable GC_ALLOC_THRESHOLD.  Here we look
 ;; for that variable, and parse it if we see it.
 ;;
 ;; examples:
 ;;
-;;   GC_THRESHOLD=500000  - raw number (B) implicit
-;;   GC_THRESHOLD=64M     - Mb
-;;   GC_THRESHOLD=1G      - Gb
+;;   GC_ALLOC_THRESHOLD=50
+;;   GC_ALLOC_THRESHOLD=5000
 ;;
 parse_gc_threshold:
     mov     rsi, [envp_ptr]
@@ -486,58 +479,13 @@ parse_gc_threshold:
     movzx   rcx, byte [rdi]
     sub     rcx, '0'
     cmp     rcx, 9
-    ja      .parse_suffix
+    ja      .parsed
     imul    rax, rax, 10
     add     rax, rcx
     inc     rdi
     jmp     .parse_digits
-
-    ;;
-    ;; Optional suffix
-    ;;
-.parse_suffix:
-    movzx   ecx, byte [rdi]
-
-    and     cl, 0DFh  ; Convert lower-case to upper
-    cmp     cl, 'K'
-    je      .kilobytes
-    cmp     cl, 'M'
-    je      .megabytes
-    cmp     cl, 'G'
-    je      .gigabytes
-    cmp     cl, 'T'
-    je      .terabytes
-    jmp     .store
-
-.kilobytes:
-    shl     rax, 10
-    inc     rdi
-    jmp     .optional_b
-
-.megabytes:
-    shl     rax, 20
-    inc     rdi
-    jmp     .optional_b
-
-.gigabytes:
-    shl     rax, 30
-    inc     rdi
-    jmp     .optional_b
-
-.terabytes:
-    shl     rax, 40
-    inc     rdi
-
-    ;; Optional trailing 'B'
-.optional_b:
-    movzx   ecx, byte [rdi]
-    and     cl, 0DFh
-    cmp     cl, 'B'
-    jne     .store
-    inc     rdi
-
-.store:
-    mov     [gc_threshold_bytes], rax
+.parsed:
+    mov     [gc_threshold], rax
 .done:
     ret
 
@@ -564,7 +512,8 @@ parse_gc_threshold:
 alloc:
     call check_stack_limit    ; Check we're not in danger of blowing the stack limit
 
-    inc qword [alloc_count]   ; count allocations
+    inc qword [alloc_count]        ; count allocations to trigger GC
+    inc qword [alloc_count_total]  ; count allocations, in total
 
     add rax, 24               ; Prefix allocation with the header size
 
@@ -1947,16 +1896,16 @@ FUNC fn_sysMINUSgc
     ret
 
 
-;; return the GC threshold, in bytes
+;; return the GC threshold value - which is the count of allocations *after* which to run GC.
 FUNC fn_sysMINUSgcMINUSthreshold
-    mov rax, [gc_threshold_bytes]
+    mov rax, [gc_threshold]
     TAG_INTEGER_REG rax
     ret
 
 
 ;; Return the internal count the allocations.
 FUNC fn_sysMINUSheapMINUSallocs
-    mov rax, [alloc_count]
+    mov rax, [alloc_count_total]
     TAG_INTEGER_REG rax
     ret
 
@@ -3276,12 +3225,13 @@ random_buffer_end:
 ;; We allow the threshold to be set in the environmental variable,
 ;; here we set the name.
 ;;
-gc_name: db "GC_THRESHOLD=",0
+gc_name: db "GC_ALLOC_THRESHOLD=",0
 
 ;;
-;; The default heap size at which we trigger GC
+;; The default number of allocations to trigger
+;; a GC process.
 ;;
-gc_threshold_bytes: dq GC_HEAP_USED_THRESHOLD
+gc_threshold: dq GC_ALLOCATION_THRESHOLD
 
 
 ;; zero section
@@ -3295,7 +3245,15 @@ stdlib_loaded:
     resq 1
 
 ;; how many times was our allocator called?
+;;
+;; This is reset every time the GC runs.
 alloc_count:
+    resq 1
+
+;; how many times was our allocator called? in total.
+;;
+;; This value is NOT reset when GC runs.
+alloc_count_total:
     resq 1
 
 ;; We can disable GC for the duration of internal functions
@@ -3437,17 +3395,13 @@ possibly_trigger_gc:
     push rbx
     push rax
 
-    ; Has the heap size grown enough to trigger
-    ; a GC process?
-    ;
-    ; The threshold is set to 20Mb by default,
-    ; but the user can change the limit at runtime
-    ; via the GC_THRESHOLD environmental variable.
-    mov     rax, [from_space]
-    add     rax, [gc_threshold_bytes]
-    mov     rcx, [alloc_ptr]
-    cmp     rcx, rax
-    jb      .ignore_gc
+    ; Have we exceeded the allocation threshold
+    mov rax, [alloc_count]
+    cmp rax, [gc_threshold]
+    jle .ignore_gc                  ; If not continue
+
+    mov qword [alloc_count], 0      ; Reset the counting total.
+                                    ; But not the *real* total.
 
     mov [gc_stack_base], rbp        ; save caller's rbp (we have no prologue, so rbp is still theirs)
     mov qword [gc_forward_regs], 1  ; forward RSI and RDI

--- a/stdlib.slisp
+++ b/stdlib.slisp
@@ -1040,7 +1040,7 @@ If no length is specified return from the given start to the end of the string."
                        (strcat (string n) suffix)))))
 
         (println "\theap objects:" (sys-heap-objects))
-        (println "\theap size:" (size bytes) " heap-limit:" (size (sys-gc-threshold)))
+        (println "\theap size:" (size bytes) " allocation-limit:" (sys-gc-threshold))
         (println "\tallocations:" (sys-heap-allocs)))))
 
 


### PR DESCRIPTION
This is the only sane way to go, but we've introduced a new "total allocation" count variable - so we can return to the user the actual number of allocations made in total.

We've also kept the ability for the user to change the limit via environmental variables.

This closes #240.